### PR TITLE
Return valid idx in _write

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -788,7 +788,7 @@ class CallbackHook(BaseHook):
                 f"of {self.data_type_name}s, "
                 f"module_name:{module_name} {var.__class__.__name__}"
             )
-            return idx
+        return idx
 
     def _write_inputs(self, name, inputs):
         self._write(name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=0)


### PR DESCRIPTION
### Description of changes:
In _write(), if the type of input or output is not a tuple/list/a particular data type, a warning is logged. An invalid idx (idx=None) is returned which may lead to an exception such as "TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'".
Returning the current idx in case var is of unknown type.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
