### PR TITLE
Dont add histograms prefix to the dashboard shown in tensorboard

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -534,7 +534,7 @@ class BaseHook:
                     if self.dry_run or np_value.dtype == np.bool or np_value.nbytes == 0:
                         return
 
-                    hist_name = f"histograms/{s_col.name}/{tensor_name}"
+                    hist_name = f"{s_col.name}/{tensor_name}"
                     self.logger.debug(f"Saving {hist_name} for global step {self.step}")
                     tb_writer.write_histogram_summary(
                         tdata=np_value, tname=hist_name, global_step=self.step


### PR DESCRIPTION
### Description of changes:
Looks weird to have a single tab for histograms in Tensorboard. Not sure when this reverted from tab name being collection_name. 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
