### PR TITLE
Remove tests from building its own package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ def compile_summary_protobuf():
 
 def build_package(version):
     packages = setuptools.find_packages(include=["smdebug", "smdebug.*"])
-    print(packages)
     setuptools.setup(
         name="smdebug",
         version=version,


### PR DESCRIPTION
### Description of changes:

Before, running `pip install smdebug-**.whl` would discover the top-level tests module (which has an `__init__.py` file) and install that as a separate module. So we'd have the smdebug module and the tests module. This limits that to only install smdebug and its subpackages.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
