### PR TITLE
Fix exception when trying to delete callable in destructor

### DIFF
--- a/smdebug/core/singleton_utils.py
+++ b/smdebug/core/singleton_utils.py
@@ -7,6 +7,9 @@ import smdebug.(pytorch | tensorflow | mxnet) as smd
 hook = smd.hook()
 """
 
+# Standard Library
+import atexit
+
 # First Party
 from smdebug.core.logger import get_logger
 
@@ -68,6 +71,8 @@ def set_hook(custom_hook: "BaseHook") -> None:
 
     global _ts_hook
     _ts_hook = custom_hook
+
+    atexit.register(del_hook)
 
 
 def del_hook() -> None:


### PR DESCRIPTION
### Description of changes:
Delete the hook explicitly when unloading modules, so that TF doesn't try to delete the callable after module was unloaded. This fixes the following error seen in ZCC environments.

```
Exception ignored in: <bound method BaseSession._Callable.__del__ of <tensorflow.python.client.session.BaseSession._Callable object at 0x7f5a242a44a8>>
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/tensorflow_p36/lib/python3.6/site-packages/tensorflow_core/python/client/session.py", line 1487, in __del__
AttributeError: 'NoneType' object has no attribute 'TF_SessionReleaseCallable'
```

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
