### PR TITLE
Stop Waiting For Collection Files If Training Has Ended

### DIFF
--- a/smdebug/exceptions.py
+++ b/smdebug/exceptions.py
@@ -11,6 +11,14 @@ class StepNotYetAvailable(Exception):
         return "Step {} of mode {} not yet available".format(self.step, self.mode.name)
 
 
+class MissingCollectionFiles(Exception):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "Training job has ended. All the collection files could not be loaded"
+
+
 class IndexReaderException(Exception):
     def __init__(self, message):
         self.message = message

--- a/smdebug/trials/trial.py
+++ b/smdebug/trials/trial.py
@@ -25,7 +25,12 @@ from smdebug.core.utils import (
     match_inc,
     serialize_tf_device,
 )
-from smdebug.exceptions import NoMoreData, StepUnavailable, TensorUnavailable
+from smdebug.exceptions import (
+    MissingCollectionFiles,
+    NoMoreData,
+    StepUnavailable,
+    TensorUnavailable,
+)
 
 
 class Trial(ABC):
@@ -156,13 +161,10 @@ class Trial(ABC):
                 if has_training_ended(self.path):
                     """ _fetch should have returned all the collection files if the training job has ended """
                     if len(collection_files) < number_of_collection_file_to_wait_for:
-                        self.logger.warning(
-                            "Training job has ended. All the collection files could not be loaded"
-                        )
-                    break
+                        raise MissingCollectionFiles
 
         _fetch()
-        _wait_for_collection_files(0)  # wait for the first collection file
+        _wait_for_collection_files(1)  # wait for the first collection file
         self._read_collections(collection_files)
         _wait_for_collection_files(self.num_workers)  # wait for all the collection files
         for collection_file in collection_files:

--- a/tests/analysis/trials/test_load_collections.py
+++ b/tests/analysis/trials/test_load_collections.py
@@ -4,6 +4,7 @@
 import pytest
 
 # First Party
+from smdebug.exceptions import MissingCollectionFiles
 from smdebug.trials import create_trial
 
 
@@ -18,7 +19,10 @@ def test_load_collection_files_from_completed_job():
     :return:
     """
     path = "s3://tornasole-testing/collection-tests/all-collection-files-present/"
-    trial = create_trial(path)
+    try:
+        trial = create_trial(path)
+    except MissingCollectionFiles:
+        assert False
     assert len(trial.workers()) == 2001
 
 
@@ -34,8 +38,11 @@ def test_load_collection_files_from_completed_job_with_missing_files():
     :return:
     """
     path = "s3://tornasole-testing/collection-tests/collection-files-missing/"
-    trial = create_trial(path)
-    assert len(trial.workers()) == 1446
+    try:
+        trial = create_trial(path)
+        assert False
+    except MissingCollectionFiles:
+        assert True
 
 
 @pytest.mark.slow
@@ -51,5 +58,8 @@ def test_load_collection_files_from_incomplete_job():
     :return:
     """
     path = "s3://tornasole-testing/collection-tests/all-collection-files-present-job-incomplete/"
-    trial = create_trial(path)
+    try:
+        trial = create_trial(path)
+    except MissingCollectionFiles:
+        assert False
     assert len(trial.workers()) == 2001


### PR DESCRIPTION
### Description of changes:
- check if has_training_ended and break if True

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
