### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ SageMaker Debugger can be used inside or outside of SageMaker. There are three m
 - SageMaker Bring-Your-Own-Container: Here you specify the rules to use, and modify your training script.
 - Non-SageMaker: Here you write custom rules (or manually analyze the tensors) and modify your training script. See the second example above.
 
-The reason for different setups is that SageMaker Zero-Script-Change uses custom framework forks of TensorFlow, PyTorch, MXNet, and XGBoost to save tensors automatically.
+The reason for different setups is that SageMaker Zero-Script-Change (via Deep Learning Containers) uses custom framework forks of TensorFlow, PyTorch, MXNet, and XGBoost to save tensors automatically.
 These framework forks are not available in custom containers or non-SM environments, so you must modify your training script in these environments.
 
-See the [SageMaker page](https://link.com) for details on SageMaker Zero-Script-Change and BYOC experience.\
+See the [SageMaker page](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/sagemaker.md) for details on SageMaker Zero-Code-Change and BYOC experience.\
 See the frameworks pages for details on modifying the training script:
-- [TensorFlow](https://link.com)
-- [PyTorch](https://link.com)
-- [MXNet](https://link.com)
-- [XGBoost](https://link.com)
+- [TensorFlow](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/tensorflow.md)
+- [PyTorch](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/pytorch.md)
+- [MXNet](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/mxnet.md)
+- [XGBoost](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/xgboost.md)

--- a/docs/sagemaker.md
+++ b/docs/sagemaker.md
@@ -1,17 +1,22 @@
 # SageMaker
 
 There are two cases for SageMaker:
-- Zero-Script-Change (ZSC): Here you specify which rules to use, and run your existing script.
+- Zero-Code-Change (ZCC): Here you specify which rules to use, and run your existing script.
     - Supported in Deep Learning Containers: `TensorFlow==1.15, PyTorch==1.3, MXNet==1.6`
 - Bring-Your-Own-Container (BYOC): Here you specify the rules to use, and modify your training script.
-    - Supported with `TensorFlow==1.13/1.14/1.15, PyTorch==1.2/1.3, MXNet==1.4,1.5,1.6`
+    - Supported with `TensorFlow==1.13/1.14/1.15, PyTorch==1.2/1.3, MXNet==1.4/1.5/1.6`
 
-Table of Contents
-- [Configuration Details](#version-support)
-- [Using a Custom Container](#byoc-example)
+The reason for different setups is that SageMaker Zero-Script-Change (via Deep Learning Containers) uses custom framework forks of TensorFlow, PyTorch, MXNet, and XGBoost to save tensors automatically.
+These framework forks are not available in custom containers or non-SM environments, so you must modify your training script in these environments.
 
 ## Configuration Details
-The DebuggerHookConfig is the main object.
+
+This configuration is used for both ZCC and BYOC. The only difference is that with a custom container, you modify your training script as well. See the framework pages below for details on how to modify your training script.
+
+- [TensorFlow](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/tensorflow.md)
+- [PyTorch](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/pytorch.md)
+- [MXNet](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/mxnet.md)
+- [XGBoost](https://github.com/awslabs/sagemaker-debugger/blob/master/docs/xgboost.md)
 
 ```python
 rule = sagemaker.debugger.Rule.sagemaker(
@@ -100,25 +105,13 @@ sagemaker_simple_estimator = sagemaker.tensorflow.TensorFlow(
 sagemaker_simple_estimator.fit()
 ```
 
-## Using a Custom Container
-To use a custom container (without the framework forks), you should modify your script.
-Use the same sagemaker Estimator setup as shown below, and in your script, call
-
-```python
-hook = smd.{hook_class}.create_from_json_file()
-```
-
-and modify the rest of your script as shown in the API docs. Click on your desired framework below.
-- [TensorFlow](https://link.com)
-- [PyTorch](https://link.com)
-- [MXNet](https://link.com)
-- [XGBoost](https://link.com)
 
 
-## Comprehensive Rule List
+
+## List of Builtin Rules
 Full list of rules is:
 | Rule Name | Behavior |
-| --- | --- |
+|---|---|
 | `vanishing_gradient` | Detects a vanishing gradient. |
 | `all_zero` | ??? |
 | `check_input_images` | ??? |

--- a/docs/tensorflow.md
+++ b/docs/tensorflow.md
@@ -12,13 +12,25 @@ Python API supported versions: Tensorflow 1.13, 1.14, 1.15. Keras 2.3.
 - [Estimator Example](#estimator-example)
 - [Full API](#full-api)
 
-## How to Use
-1. `import smdebug.tensorflow as smd`
-2. Instantiate a hook. `smd.{hook_class}.create_from_json_file()` in a SageMaker environment or `smd.{hook_class}()` elsewhere.
-3. Pass the hook to the model as a callback.
-4. If using a custom container or outside of SageMaker, wrap the optimizer with `optimizer = hook.wrap_optimizer(optimizer)`.
+---
 
-(Optional): Configure collections. See the [Common API](https://link.com) page for details on how to do this.
+## How to Use
+```import smdebug.tensorflow as smd```
+### 1. Create a hook
+If using SageMaker, you will configure the hook in SageMaker Estimator. Instantiate it with
+`smd.{hook_class}.create_from_json_file()`.\
+Otherwise, call the hook class constructor, `smd.{hook_class}()`. Details are below for tf.keras, MonitoredSession, or Estimator.
+
+### 2. Pass the hook to the model as a callback
+The keyword is `callbacks=[hook]` for tf.keras. It is `hooks=[hook]` for MonitoredSession and Estimator.
+
+### 3. (Optional) Wrap the optimizer
+If you are accessing the GRADIENTS collection, and you are in BYOC or non-SageMaker mode, call `optimizer = hook.wrap_optimizer(optimizer)`.
+
+### 4. (Optional) Configure collections, SaveConfig, ReductionConfig
+See the [Common API](https://link.com) page for details on how to do this.
+
+---
 
 ## tf.keras Example
 ```python
@@ -35,46 +47,9 @@ model.fit(x_train, y_train, epochs=args.epochs, callbacks=[hook])
 model.evaluate(x_test, y_test, callbacks=[hook])
 ```
 
-## MonitoredSession Example
-```python
-import smdebug.tensorflow as smd
-hook = smd.SessionHook(out_dir=args.out_dir)
-
-loss = tf.reduce_mean(tf.matmul(...), name="loss")
-optimizer = tf.train.AdamOptimizer(args.lr)
-
-# Wrap the optimizer
-optimizer = hook.wrap_optimizer(optimizer)
-
-# Add the hook as a callback
-sess = tf.train.MonitoredSession(hooks=[hook])
-
-sess.run([loss, ...])
-```
-
-## Estimator Example
-```python
-import smdebug.tensorflow as smd
-hook = smd.EstimatorHook(out_dir=args.out_dir)
-
-train_input_fn, eval_input_fn = ...
-estimator = tf.estimator.Estimator(...)
-
-# Set the mode and pass the hook as callback
-hook.set_mode(mode=smd.modes.TRAIN)
-estimator.train(input_fn=train_input_fn, steps=args.steps, hooks=[hook])
-
-hook.set_mode(mode=smd.modes.EVAL)
-estimator.evaluate(input_fn=eval_input_fn, steps=args.steps, hooks=[hook])
-```
-
-
-# Full API
-
-See the [Common API](https://link.com) page for details about Collection, SaveConfig, and ReductionConfig.\
-See the [Analysis](https://link.com) page for details about analyzing a training job.
-
 ## KerasHook
+
+Use this if in a non-SageMaker environment. In SageMaker, call `smd.KerasHook.create_from_json_file()`.
 ```python
 __init__(
     out_dir,
@@ -104,18 +79,35 @@ Initializes the hook. Pass this object as a callback to Keras' `model.fit(), mod
 ```python
 wrap_optimizer(
     self,
-    optimizer: Tuple[tf.train.Optimizer, tf.keras.Optimizer],
+    optimizer: Union[tf.train.Optimizer, tf.keras.Optimizer],
 )
 ```
 Adds functionality to the optimizer object to log gradients. Returns the original optimizer and doesn't change the optimization process.
 
-`optimizer` (Tuple[tf.train.Optimizer, tf.keras.Optimizer]): The optimizer.
+`optimizer` (Union[tf.train.Optimizer, tf.keras.Optimizer]): The optimizer.
 
+---
 
-## EstimatorHook / SessionHook
-EstimatorHook is used for the tf.estimator.Estimator interface.\
-SessionHook is used for tf.train.MonitoredSession objects (tf.Session objects are not supported).\
-Because Estimator uses MonitoredSession under the hood, these names are aliases to the same class. They have two separate names for clarity.
+## MonitoredSession Example
+```python
+import smdebug.tensorflow as smd
+hook = smd.SessionHook(out_dir=args.out_dir)
+
+loss = tf.reduce_mean(tf.matmul(...), name="loss")
+optimizer = tf.train.AdamOptimizer(args.lr)
+
+# Wrap the optimizer
+optimizer = hook.wrap_optimizer(optimizer)
+
+# Add the hook as a callback
+sess = tf.train.MonitoredSession(hooks=[hook])
+
+sess.run([loss, ...])
+```
+
+## SessionHook
+Use this if in a non-SageMaker environment. In SageMaker, call `smd.SessionHook.create_from_json_file()`.
+
 ```python
 __init__(
     out_dir,
@@ -152,18 +144,63 @@ wrap_optimizer(
 ```
 Adds functionality to the optimizer object to log gradients. Returns the original optimizer and doesn't change the optimization process.
 
-## Concepts
-The steps to use Tornasole in any framework are:
+---
 
-1. Create a `hook`.
-2. Register your model and optimizer with the hook.
-3. Specify the `rule` to be used.
-4. After training, create a `trial` to manually analyze the tensors.
+## Estimator Example
+```python
+import smdebug.tensorflow as smd
+hook = smd.EstimatorHook(out_dir=args.out_dir)
 
-See the [API page](https://link.com) for more details.
+train_input_fn, eval_input_fn = ...
+estimator = tf.estimator.Estimator(...)
 
-## Detailed Links
-- [Full API](https://link.com)
-- [Rules and Trials](https://link.com)
-- [Distributed Training](https://link.com)
-- [TensorBoard](https://link.com)
+# Set the mode and pass the hook as callback
+hook.set_mode(mode=smd.modes.TRAIN)
+estimator.train(input_fn=train_input_fn, steps=args.steps, hooks=[hook])
+
+hook.set_mode(mode=smd.modes.EVAL)
+estimator.evaluate(input_fn=eval_input_fn, steps=args.steps, hooks=[hook])
+```
+
+## EstimatorHook
+Use this if in a non-SageMaker environment. In SageMaker, call `smd.EstimatorHook.create_from_json_file()`.
+
+```python
+__init__(
+    out_dir,
+    export_tensorboard = False,
+    tensorboard_dir = None,
+    dry_run = False,
+    reduction_config = None,
+    save_config = None,
+    include_regex = None,
+    include_collections= None,
+    save_all = False,
+    include_workers = "one"
+)
+```
+
+Pass this object as a hook to tf.train.MonitoredSession's `run()` method.
+
+`out_dir` (str): Where to write the recorded tensors and metadata.\
+`export_tensorboard` (bool): Whether to use TensorBoard logs.\
+`tensorboard_dir` (str): Where to save TensorBoard logs.\
+`dry_run` (bool): If true, don't write any files.\
+`reduction_config` (ReductionConfig object): See the Common API page.\
+`save_config` (SaveConfig object): See the Common API page.\
+`include_regex` (list[str]): List of additional regexes to save.\
+`include_collections` (list[str]): List of collections to save.\
+`save_all` (bool): Saves all tensors and collections. May be memory-intensive and slow.\
+`include_workers` (str): Used for distributed training, can also be "all".
+
+```python
+wrap_optimizer(
+    self,
+    optimizer: tf.train.Optimizer,
+)
+```
+Adds functionality to the optimizer object to log gradients. Returns the original optimizer and doesn't change the optimization process.
+
+---
+See the [Common API](https://link.com) page for details about Collection, SaveConfig, and ReductionConfig.\
+See the [Analysis](https://link.com) page for details about analyzing a training job.


### PR DESCRIPTION
### Description of changes:

Working links on README.md
Make it clear that SM config details apply to ZCC and BYOC.
Separate tf.keras, MonitoredSession, Estimator into their own sections in `tensorflow.md`. If we like this setup and finalize on it, I'll extend the format to pytorch and mxnet.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
