### PR TITLE
Skip logging the input tensors to the loss block.

### DIFF
--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -154,8 +154,9 @@ class Hook(CallbackHook):
         # This overwhelms the logs; turn back on if you really need it
         # logger.debug("Processing the global step {0} for block {1}".format(self.step, block_name))
 
-        # Output input tensor
-        self._write_inputs(block_name, inputs)
+        # Output input tensor if it is not a loss block
+        if isinstance(block, mx.gluon.loss.Loss) is False:
+            self._write_inputs(block_name, inputs)
 
         # Output output tensors
         self._write_outputs(block_name, outputs)

--- a/tests/mxnet/test_hook_loss_collection.py
+++ b/tests/mxnet/test_hook_loss_collection.py
@@ -33,6 +33,9 @@ def test_loss_collection_default():
     loss_val = loss_tensor.value(step_num=1)
     assert len(loss_val) > 0
 
+    # Assert that we are not logging the inputs to loss block.
+    input_loss_tensors = tr.tensor_names(regex=".*loss._input*")
+    assert len(input_loss_tensors) == 0
     shutil.rmtree(out_dir)
 
 


### PR DESCRIPTION
### Description of changes:
The PR includes the change which prevents logging the input tensors to the loss block.
We will only log the output of loss blocks.


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
