### PR TITLE
Set mode on each batch for Keras

### DIFF
--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -479,6 +479,11 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         if self._is_not_supported():
             return
 
+        # set mode for each batch as when users run model.fit() and pass validation data
+        # through the optional argument, then mode_begin is not called for the training steps
+        # after first evaluation during training
+        self.set_mode(mode)
+
         self._close_writers()
         self._increment_step()
 


### PR DESCRIPTION
### Description of changes:
set mode for each batch as when users run model.fit() and pass validation data
through the optional argument, then mode_begin is not called for the training steps
after first evaluation during training

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
