### PR TITLE
Change default save interval to 500

### DIFF
--- a/smdebug/core/save_config.py
+++ b/smdebug/core/save_config.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Union
 from smdebug.core.modes import ModeKeys
 from smdebug.core.utils import step_in_range
 
-DEFAULT_SAVE_CONFIG_INTERVAL = 100
+DEFAULT_SAVE_CONFIG_INTERVAL = 500
 DEFAULT_SAVE_CONFIG_START_STEP = 0
 DEFAULT_SAVE_CONFIG_END_STEP = None
 DEFAULT_SAVE_CONFIG_SAVE_STEPS = []


### PR DESCRIPTION
### Description of changes:
Reducing the frequency of default emission so load is less on SM infra

Default in XGBoost is still 10

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
