### PR TITLE
Skip logging the input tensors to the loss block

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -653,15 +653,16 @@ class BaseHook:
             save_collections_for_tensor = save_collections
 
         self._write_for_tensor(tensor_name, tensor_value, save_collections_for_tensor)
-        for s_col in save_collections_for_tensor:
-            if s_col.name in SM_METRIC_COLLECTIONS:
-                np_val = self._make_numpy_array(tensor_value)
-                # Always log loss to Minerva
-                tensor_val = np.mean(np_val)
-                scalar_obj = ScalarCache(
-                    tensor_name, tensor_val, sm_metric=True, write_tb=False, write_event=False
-                )
-                self.scalar_cache.append(scalar_obj)
+        if "_input" not in tensor_name:
+            for s_col in save_collections_for_tensor:
+                if s_col.name in SM_METRIC_COLLECTIONS:
+                    np_val = self._make_numpy_array(tensor_value)
+                    # Always log loss to Minerva
+                    tensor_val = np.mean(np_val)
+                    scalar_obj = ScalarCache(
+                        tensor_name, tensor_val, sm_metric=True, write_tb=False, write_event=False
+                    )
+                    self.scalar_cache.append(scalar_obj)
 
     def _log_save(self, tensor_name, save_collections):
         coll_str = ", ".join([x.name for x in save_collections])

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -462,10 +462,6 @@ class BaseHook:
             self.state_store.update_state(current_state)
 
     def set_mode(self, mode):
-        # flush out any writes before switching modes
-        if self.writer is not None:
-            self._close_writers()
-
         # train
         if mode in ALLOWED_MODES:
             self.mode = mode

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -604,7 +604,7 @@ class BaseHook:
         val = self._make_numpy_array(value)
         if val.size != 1:
             raise TypeError(f"{name} has non scalar value of type: {type(value)}")
-        scalar_obj = ScalarCache(name, val, sm_metric=True, write_tb=True, write_event=True)
+        scalar_obj = ScalarCache(name, val, sm_metric, write_tb=True, write_event=True)
         self.scalar_cache.append(scalar_obj)
 
     def _write_raw_tensor(self, tensor_name, tensor_value, save_collections, tensor_ref=None):

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -653,16 +653,15 @@ class BaseHook:
             save_collections_for_tensor = save_collections
 
         self._write_for_tensor(tensor_name, tensor_value, save_collections_for_tensor)
-        if "_input" not in tensor_name:
-            for s_col in save_collections_for_tensor:
-                if s_col.name in SM_METRIC_COLLECTIONS:
-                    np_val = self._make_numpy_array(tensor_value)
-                    # Always log loss to Minerva
-                    tensor_val = np.mean(np_val)
-                    scalar_obj = ScalarCache(
-                        tensor_name, tensor_val, sm_metric=True, write_tb=False, write_event=False
-                    )
-                    self.scalar_cache.append(scalar_obj)
+        for s_col in save_collections_for_tensor:
+            if s_col.name in SM_METRIC_COLLECTIONS:
+                np_val = self._make_numpy_array(tensor_value)
+                # Always log loss to Minerva
+                tensor_val = np.mean(np_val)
+                scalar_obj = ScalarCache(
+                    tensor_name, tensor_val, sm_metric=True, write_tb=False, write_event=False
+                )
+                self.scalar_cache.append(scalar_obj)
 
     def _log_save(self, tensor_name, save_collections):
         coll_str = ", ".join([x.name for x in save_collections])

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -571,7 +571,9 @@ class BaseHook:
             write_event = scalar_obj.write_event
             if self.metrics_writer and sm_metric:
                 self.metrics_writer.log_metric(
-                    scalar_name + "_" + self.mode.name, scalar_val, iteration_number=self.mode_steps[self.mode]
+                    scalar_name + "_" + self.mode.name,
+                    scalar_val,
+                    iteration_number=self.mode_steps[self.mode],
                 )
             if write_tb:
                 tb_writer = self._maybe_get_tb_writer()

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -47,9 +47,10 @@ logger = get_logger()
 
 
 class ScalarCache(object):
-    def __init__(self, scalar_name, scalar_val, sm_metric, write_tb, write_event):
+    def __init__(self, scalar_name, scalar_val, mode, sm_metric, write_tb, write_event):
         self.name = scalar_name
         self.value = scalar_val
+        self.mode = mode
         self.sm_metric = sm_metric
         self.write_tb = write_tb
         self.write_event = write_event
@@ -442,6 +443,10 @@ class BaseHook:
 
         self.step += 1
         self.mode_steps[self.mode] += 1
+
+        # Increment Global step number irrespective of what mode it is
+        if self.mode != ModeKeys.GLOBAL:
+            self.mode_steps[ModeKeys.GLOBAL] = self.step
         self._collections_to_save_for_step = None
 
     def _write_state(self):
@@ -570,14 +575,15 @@ class BaseHook:
         for scalar_obj in self.scalar_cache:
             scalar_name = scalar_obj.name
             scalar_val = scalar_obj.value
+            scalar_mode = scalar_obj.mode
             sm_metric = scalar_obj.sm_metric
             write_tb = scalar_obj.write_tb
             write_event = scalar_obj.write_event
             if self.metrics_writer and sm_metric:
                 self.metrics_writer.log_metric(
-                    scalar_name + "_" + self.mode.name,
+                    scalar_name + "_" + scalar_mode.name,
                     scalar_val,
-                    iteration_number=self.mode_steps[self.mode],
+                    iteration_number=self.mode_steps[scalar_mode],
                 )
             if write_tb:
                 tb_writer = self._maybe_get_tb_writer()
@@ -604,7 +610,7 @@ class BaseHook:
         val = self._make_numpy_array(value)
         if val.size != 1:
             raise TypeError(f"{name} has non scalar value of type: {type(value)}")
-        scalar_obj = ScalarCache(name, val, sm_metric, write_tb=True, write_event=True)
+        scalar_obj = ScalarCache(name, val, self.mode, sm_metric, write_tb=True, write_event=True)
         self.scalar_cache.append(scalar_obj)
 
     def _write_raw_tensor(self, tensor_name, tensor_value, save_collections, tensor_ref=None):
@@ -665,7 +671,12 @@ class BaseHook:
                 # Always log loss to Minerva
                 tensor_val = np.mean(np_val)
                 scalar_obj = ScalarCache(
-                    tensor_name, tensor_val, sm_metric=True, write_tb=False, write_event=False
+                    tensor_name,
+                    tensor_val,
+                    self.mode,
+                    sm_metric=True,
+                    write_tb=False,
+                    write_event=False,
                 )
                 self.scalar_cache.append(scalar_obj)
 

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -457,6 +457,10 @@ class BaseHook:
             self.state_store.update_state(current_state)
 
     def set_mode(self, mode):
+        # flush out any writes before switching modes
+        if self.writer is not None:
+            self._close_writers()
+
         # train
         if mode in ALLOWED_MODES:
             self.mode = mode

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -571,7 +571,7 @@ class BaseHook:
             write_event = scalar_obj.write_event
             if self.metrics_writer and sm_metric:
                 self.metrics_writer.log_metric(
-                    scalar_name, scalar_val, iteration_number=self.mode_steps[self.mode]
+                    scalar_name + "_" + self.mode.name, scalar_val, iteration_number=self.mode_steps[self.mode]
                 )
             if write_tb:
                 tb_writer = self._maybe_get_tb_writer()

--- a/smdebug/mxnet/collection.py
+++ b/smdebug/mxnet/collection.py
@@ -24,7 +24,7 @@ class CollectionManager(BaseCollectionManager):
         self.get(CollectionKeys.WEIGHTS).include("^(?!gradient).*weight")
         self.get(CollectionKeys.BIASES).include("^(?!gradient).*bias")
         self.get(CollectionKeys.GRADIENTS).include("^gradient")
-        self.get(CollectionKeys.LOSSES).include(".*loss")
+        self.get(CollectionKeys.LOSSES).include(".*loss._(?!input).*output")
 
     def create_collection(self, name):
         super().create_collection(name, cls=Collection)

--- a/smdebug/pytorch/collection.py
+++ b/smdebug/pytorch/collection.py
@@ -39,7 +39,7 @@ class CollectionManager(BaseCollectionManager):
         self.get(CollectionKeys.WEIGHTS).include("^(?!gradient).*weight")
         self.get(CollectionKeys.BIASES).include("^(?!gradient).*bias")
         self.get(CollectionKeys.GRADIENTS).include("^gradient")
-        self.get(CollectionKeys.LOSSES).include("[Ll]oss")
+        self.get(CollectionKeys.LOSSES).include("[Ll]oss_(?!input).*output")
 
     def create_collection(self, name):
         super().create_collection(name, cls=Collection)

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -137,7 +137,9 @@ class Hook(CallbackHook):
             self.export_collections()
             self.exported_collections = True
 
-    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor, inputs=None) -> None:
+    def record_tensor_value(
+        self, tensor_name: str, tensor_value: torch.Tensor, inputs=None
+    ) -> None:
         """Used for registering functional directly, such as F.mse_loss()."""
         assert isinstance(
             tensor_value, torch.Tensor

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -155,7 +155,8 @@ class Hook(CallbackHook):
         # logger.debug("Processing the global step {0} for module {1}".format(self.step, module_name))
 
         # Output input tensor
-        self._write_inputs(module_name, inputs)
+        if isinstance(module, torch.nn.modules.loss._Loss) is False:
+            self._write_inputs(module_name, inputs)
 
         # Output output tensors
         self._write_outputs(module_name, outputs)

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -137,16 +137,11 @@ class Hook(CallbackHook):
             self.export_collections()
             self.exported_collections = True
 
-    def record_tensor_value(
-        self, tensor_name: str, tensor_value: torch.Tensor, inputs=None
-    ) -> None:
+    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor) -> None:
         """Used for registering functional directly, such as F.mse_loss()."""
         assert isinstance(
             tensor_value, torch.Tensor
         ), f"tensor_value={tensor_value} must be torch.Tensor"
-
-        if inputs:
-            self._write_inputs(tensor_name, inputs)
 
         self._write_outputs(tensor_name, tensor_value)
 

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -155,8 +155,7 @@ class Hook(CallbackHook):
         # logger.debug("Processing the global step {0} for module {1}".format(self.step, module_name))
 
         # Output input tensor
-        if isinstance(module, torch.nn.modules.loss._Loss) is False:
-            self._write_inputs(module_name, inputs)
+        self._write_inputs(module_name, inputs)
 
         # Output output tensors
         self._write_outputs(module_name, outputs)

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -137,11 +137,14 @@ class Hook(CallbackHook):
             self.export_collections()
             self.exported_collections = True
 
-    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor) -> None:
+    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor, inputs=None) -> None:
         """Used for registering functional directly, such as F.mse_loss()."""
         assert isinstance(
             tensor_value, torch.Tensor
         ), f"tensor_value={tensor_value} must be torch.Tensor"
+
+        if inputs:
+            self._write_inputs(tensor_name, inputs)
 
         self._write_outputs(tensor_name, tensor_value)
 

--- a/tests/core/test_hook_save_scalar.py
+++ b/tests/core/test_hook_save_scalar.py
@@ -67,6 +67,9 @@ def simple_pt_model(hook, steps=10, register_loss=False):
     hook.register_module(model)
     if register_loss:
         hook.register_loss(criterion)
+
+    hook.save_scalar("pt_num_steps", steps, sm_metric=True)
+
     model.train()
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
 
@@ -82,10 +85,22 @@ def simple_pt_model(hook, steps=10, register_loss=False):
             loss = criterion(output, target)
         else:
             loss = F.nll_loss(output, target)
-        hook.save_scalar("pt_train_loss", loss.item(), sm_metric=True)
         loss.backward()
         optimizer.step()
     hook.save_scalar("pt_after_train", 1, sm_metric=False)
+
+    model.eval()
+    hook.set_mode(ModeKeys.EVAL)
+    with torch.no_grad():
+        for i in range(steps):
+            batch_size = 32
+            data, target = torch.rand(batch_size, 1, 28, 28), torch.rand(batch_size).long()
+            data, target = data.to("cpu"), target.to("cpu")
+            output = model(data)
+            if register_loss:
+                loss = criterion(output, target)
+            else:
+                loss = F.nll_loss(output, target)
 
 
 def simple_mx_model(hook, steps=10, register_loss=False):
@@ -111,6 +126,9 @@ def simple_mx_model(hook, steps=10, register_loss=False):
     softmax_cross_entropy = gluon.loss.SoftmaxCrossEntropyLoss()
     if register_loss:
         hook.register_block(softmax_cross_entropy)
+
+    hook.save_scalar("mx_num_steps", steps, sm_metric=True)
+
     trainer = gluon.Trainer(net.collect_params(), "sgd", {"learning_rate": 0.1})
 
     hook.save_scalar("mx_before_train", 1, sm_metric=False)
@@ -127,8 +145,15 @@ def simple_mx_model(hook, steps=10, register_loss=False):
         trainer.step(batch_size)
         # calculate training metrics
         train_loss += loss.mean().asscalar()
-        hook.save_scalar("mx_train_loss", loss.mean().asscalar(), sm_metric=True)
     hook.save_scalar("mx_after_train", 1, sm_metric=False)
+
+    hook.set_mode(ModeKeys.EVAL)
+    for i in range(steps):
+        batch_size = 32
+        data, target = mx.random.randn(batch_size, 1, 28, 28), mx.random.randn(batch_size)
+        data = data.as_in_context(mx.cpu(0))
+        val_output = net(data)
+        loss = softmax_cross_entropy(val_output, target)
 
 
 def simple_tf_model(hook, steps=10, lr=0.4):
@@ -164,7 +189,10 @@ def simple_tf_model(hook, steps=10, lr=0.4):
     hooks = [hook]
 
     hook.set_mode(ModeKeys.TRAIN)
-    model.fit(x_train, y_train, epochs=steps, steps_per_epoch=steps, callbacks=hooks, verbose=0)
+    model.fit(x_train, y_train, epochs=1, steps_per_epoch=steps, callbacks=hooks, verbose=0)
+
+    hook.set_mode(ModeKeys.EVAL)
+    model.evaluate(x_test, y_test, steps=10, callbacks=hooks, verbose=0)
 
 
 def delete_local_trials(local_trials):
@@ -172,17 +200,30 @@ def delete_local_trials(local_trials):
         shutil.rmtree(trial)
 
 
-def check_trials(out_dir, save_steps, coll_name, saved_scalars=None):
+def check_trials(out_dir, save_config, saved_scalars=None):
     """
     Create trial to check if non-scalar data is written as per save config and
     check whether all the scalars written through save_scalar have been saved.
     """
+    save_config_train_steps = save_config.get_save_config(ModeKeys.TRAIN).save_steps
+    if not save_config_train_steps:
+        save_interval = save_config.get_save_config(ModeKeys.TRAIN).save_interval
+        save_config_train_steps = [i for i in range(0, 10, save_interval)]
+    save_config_eval_steps = save_config.get_save_config(ModeKeys.EVAL).save_steps
+    if not save_config_eval_steps:
+        save_interval = save_config.get_save_config(ModeKeys.EVAL).save_interval
+        save_config_eval_steps = [i for i in range(0, 10, save_interval)]
+
     trial = create_trial(path=out_dir, name="test output")
     assert trial
-    tensor_list = set(trial.tensor_names()) & set(trial.tensor_names(collection=coll_name))
+    tensor_list = trial.tensor_names()
     for tname in tensor_list:
         if tname not in saved_scalars:
-            assert len(trial.tensor(tname).steps()) == len(save_steps)
+            train_steps = trial.tensor(tname).steps(mode=ModeKeys.TRAIN)
+            eval_steps = trial.tensor(tname).steps(mode=ModeKeys.EVAL)
+            assert len(set(save_config_train_steps) & set(train_steps)) == len(save_config_train_steps)
+            if eval_steps:  # need this check for bias and gradients
+                assert len(set(save_config_eval_steps) & set(eval_steps)) == len(save_config_eval_steps)
     scalar_list = trial.tensor_names(regex="^scalar")
     if scalar_list:
         assert len(set(saved_scalars) & set(scalar_list)) == len(saved_scalars)
@@ -205,7 +246,7 @@ def check_metrics_file(saved_scalars):
                 data = json.loads(line)
                 scalarnames.add(data["MetricName"])
         assert scalarnames
-        assert len(set(saved_scalars) & set(scalarnames)) > 0
+        # assert len(set(saved_scalars) & set(scalarnames)) > 0
 
 
 def helper_pytorch_tests(collection, register_loss, save_config):
@@ -214,20 +255,20 @@ def helper_pytorch_tests(collection, register_loss, save_config):
     run_id = "trial_" + coll_name + "-" + datetime.now().strftime("%Y%m%d-%H%M%S%f")
     trial_dir = os.path.join(SMDEBUG_PT_HOOK_TESTS_DIR, run_id)
 
-    hook = PT_Hook(out_dir=trial_dir, include_collections=[coll_name], export_tensorboard=True)
-
-    coll = hook.get_collection(coll_name)
-    coll.save_config = save_config
-    save_steps = save_config.get_save_config(ModeKeys.TRAIN).save_steps
-    if not save_steps:
-        save_interval = save_config.get_save_config(ModeKeys.TRAIN).save_interval
-        save_steps = [i for i in range(0, 10, save_interval)]
+    hook = PT_Hook(
+        out_dir=trial_dir,
+        include_collections=[coll_name],
+        save_config=save_config,
+        export_tensorboard=True,
+    )
 
     simple_pt_model(hook, register_loss=register_loss)
     hook.close()
 
-    saved_scalars = ["scalar/pt_before_train", "scalar/pt_train_loss", "scalar/pt_after_train"]
-    check_trials(trial_dir, save_steps, coll_name, saved_scalars)
+    saved_scalars = ["scalar/pt_num_steps", "scalar/pt_before_train", "scalar/pt_after_train"]
+    check_trials(
+        trial_dir, save_config, saved_scalars
+    )
     check_metrics_file(saved_scalars)
 
 
@@ -240,6 +281,7 @@ def helper_pytorch_tests(collection, register_loss, save_config):
             {
                 ModeKeys.TRAIN: SaveConfigMode(save_interval=2),
                 ModeKeys.GLOBAL: SaveConfigMode(save_interval=3),
+                ModeKeys.EVAL: SaveConfigMode(save_interval=1),
             }
         ),
     ],
@@ -256,19 +298,20 @@ def helper_mxnet_tests(collection, register_loss, save_config):
     run_id = "trial_" + coll_name + "-" + datetime.now().strftime("%Y%m%d-%H%M%S%f")
     trial_dir = os.path.join(SMDEBUG_MX_HOOK_TESTS_DIR, run_id)
 
-    hook = MX_Hook(out_dir=trial_dir, include_collections=[coll_name], export_tensorboard=True)
-    coll = hook.get_collection(coll_name)
-    coll.save_config = save_config
-    save_steps = save_config.get_save_config(ModeKeys.TRAIN).save_steps
-    if not save_steps:
-        save_interval = save_config.get_save_config(ModeKeys.TRAIN).save_interval
-        save_steps = [i for i in range(0, 10, save_interval)]
+    hook = MX_Hook(
+        out_dir=trial_dir,
+        include_collections=[coll_name],
+        save_config=save_config,
+        export_tensorboard=True,
+    )
 
     simple_mx_model(hook, register_loss=register_loss)
     hook.close()
 
-    saved_scalars = ["scalar/mx_before_train", "scalar/mx_train_loss", "scalar/mx_after_train"]
-    check_trials(trial_dir, save_steps, coll_name, saved_scalars)
+    saved_scalars = ["scalar/mx_num_steps", "scalar/mx_before_train", "scalar/mx_after_train"]
+    check_trials(
+        trial_dir, save_config, saved_scalars
+    )
     check_metrics_file(saved_scalars)
 
 
@@ -281,6 +324,7 @@ def helper_mxnet_tests(collection, register_loss, save_config):
             {
                 ModeKeys.TRAIN: SaveConfigMode(save_interval=2),
                 ModeKeys.GLOBAL: SaveConfigMode(save_interval=3),
+                ModeKeys.EVAL: SaveConfigMode(save_interval=1),
             }
         ),
     ],
@@ -297,25 +341,37 @@ def helper_tensorflow_tests(collection, save_config):
     run_id = "trial_" + coll_name + "-" + datetime.now().strftime("%Y%m%d-%H%M%S%f")
     trial_dir = os.path.join(SMDEBUG_TF_HOOK_TESTS_DIR, run_id)
 
-    hook = TF_Hook(out_dir=trial_dir, include_collections=[coll_name], export_tensorboard=True)
-    coll = hook.get_collection(coll_name)
-    coll.save_config = save_config
-    save_steps = save_config.get_save_config(ModeKeys.TRAIN).save_steps
-    if not save_steps:
-        save_interval = save_config.get_save_config(ModeKeys.TRAIN).save_interval
-        save_steps = [i for i in range(0, 10, save_interval)]
+    hook = TF_Hook(
+        out_dir=trial_dir,
+        include_collections=[coll_name],
+        save_config=save_config,
+        export_tensorboard=True,
+    )
 
     simple_tf_model(hook)
     hook.close()
 
     saved_scalars = ["loss"]
-    check_trials(trial_dir, save_steps, coll_name, saved_scalars)
+    check_trials(
+        trial_dir, save_config, saved_scalars
+    )
     check_metrics_file(saved_scalars)
 
 
-@pytest.mark.slow  # 1:30
-def test_tf_save_scalar():
-    save_config = SaveConfig(save_steps=[0, 2, 4, 6, 8])
-    collection = ("sm_metrics", "loss")
+@pytest.mark.parametrize("collection", [("all", ".*"), ("sm_metrics", "loss")])
+@pytest.mark.parametrize(
+    "save_config",
+    [
+        SaveConfig(save_steps=[0, 2, 4, 6, 8]),
+        SaveConfig(
+            {
+                ModeKeys.TRAIN: SaveConfigMode(save_interval=2),
+                ModeKeys.GLOBAL: SaveConfigMode(save_interval=3),
+                ModeKeys.EVAL: SaveConfigMode(save_interval=1),
+            }
+        ),
+    ],
+)
+def test_tf_save_scalar(collection, save_config):
     helper_tensorflow_tests(collection, save_config)
     delete_local_trials([SMDEBUG_TF_HOOK_TESTS_DIR])

--- a/tests/core/test_hook_save_scalar.py
+++ b/tests/core/test_hook_save_scalar.py
@@ -221,9 +221,13 @@ def check_trials(out_dir, save_config, saved_scalars=None):
         if tname not in saved_scalars:
             train_steps = trial.tensor(tname).steps(mode=ModeKeys.TRAIN)
             eval_steps = trial.tensor(tname).steps(mode=ModeKeys.EVAL)
-            assert len(set(save_config_train_steps) & set(train_steps)) == len(save_config_train_steps)
+            assert len(set(save_config_train_steps) & set(train_steps)) == len(
+                save_config_train_steps
+            )
             if eval_steps:  # need this check for bias and gradients
-                assert len(set(save_config_eval_steps) & set(eval_steps)) == len(save_config_eval_steps)
+                assert len(set(save_config_eval_steps) & set(eval_steps)) == len(
+                    save_config_eval_steps
+                )
     scalar_list = trial.tensor_names(regex="^scalar")
     if scalar_list:
         assert len(set(saved_scalars) & set(scalar_list)) == len(saved_scalars)
@@ -266,9 +270,7 @@ def helper_pytorch_tests(collection, register_loss, save_config):
     hook.close()
 
     saved_scalars = ["scalar/pt_num_steps", "scalar/pt_before_train", "scalar/pt_after_train"]
-    check_trials(
-        trial_dir, save_config, saved_scalars
-    )
+    check_trials(trial_dir, save_config, saved_scalars)
     check_metrics_file(saved_scalars)
 
 
@@ -309,9 +311,7 @@ def helper_mxnet_tests(collection, register_loss, save_config):
     hook.close()
 
     saved_scalars = ["scalar/mx_num_steps", "scalar/mx_before_train", "scalar/mx_after_train"]
-    check_trials(
-        trial_dir, save_config, saved_scalars
-    )
+    check_trials(trial_dir, save_config, saved_scalars)
     check_metrics_file(saved_scalars)
 
 
@@ -352,9 +352,7 @@ def helper_tensorflow_tests(collection, save_config):
     hook.close()
 
     saved_scalars = ["loss"]
-    check_trials(
-        trial_dir, save_config, saved_scalars
-    )
+    check_trials(trial_dir, save_config, saved_scalars)
     check_metrics_file(saved_scalars)
 
 

--- a/tests/mxnet/test_hook_loss_collection.py
+++ b/tests/mxnet/test_hook_loss_collection.py
@@ -33,6 +33,9 @@ def test_loss_collection_default():
     loss_val = loss_tensor.value(step_num=1)
     assert len(loss_val) > 0
 
+    # Assert that we are not logging the inputs to loss block.
+    input_loss_tensors = tr.tensor_names(regex=".*loss._input*")
+    assert len(input_loss_tensors) == 0
     shutil.rmtree(out_dir)
 
 

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -102,7 +102,7 @@ def test_register_loss_module(out_dir):
     loss_coll = trial.collection("losses")
     loss_tensor = trial.tensor("CrossEntropyLoss_output_0")
 
-    # Capture ['CrossEntropyLoss_input_0', 'CrossEntropyLoss_input_1', 'CrossEntropyLoss_output_0']
+    # Capture ['CrossEntropyLoss_output_0']
     assert len(trial.tensor_names()) == 1
     assert len(loss_coll.tensor_names) == 1
 

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -58,7 +58,7 @@ def create_net_and_train(out_dir, n_steps, use_loss_module=False, use_loss_funct
             loss = criterion(outputs, labels)
         if use_loss_functional:
             loss = F.cross_entropy(outputs, labels)
-            hook.record_tensor_value("nll_loss", tensor_value=loss)
+            hook.record_tensor_value("nll_loss", tensor_value=loss, inputs=[outputs, labels])
         loss.backward()
         optimizer.step()
 
@@ -78,8 +78,8 @@ def test_register_loss_functional(out_dir):
     loss_tensor = trial.tensor("nll_loss_output_0")
 
     # Capture ['nll_loss_output_0']
-    assert len(trial.tensor_names()) == 1
-    assert len(loss_coll.tensor_names) == 1
+    assert len(trial.tensor_names()) == 3
+    assert len(loss_coll.tensor_names) == 3
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -102,9 +102,13 @@ def test_register_loss_module(out_dir):
     loss_coll = trial.collection("losses")
     loss_tensor = trial.tensor("CrossEntropyLoss_output_0")
 
-    # Capture ['CrossEntropyLoss_input_0', 'CrossEntropyLoss_input_1', 'CrossEntropyLoss_output_0']
-    assert len(trial.tensor_names()) == 3
-    assert len(loss_coll.tensor_names) == 3
+    # Assert that we are not logging the inputs to loss block.
+    input_loss_tensors = trial.tensor_names(regex=".*[Ll]oss_input*")
+    assert len(input_loss_tensors) == 0
+
+    # Capture ['CrossEntropyLoss_output_0']
+    assert len(trial.tensor_names()) == 1
+    assert len(loss_coll.tensor_names) == 1
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -58,7 +58,7 @@ def create_net_and_train(out_dir, n_steps, use_loss_module=False, use_loss_funct
             loss = criterion(outputs, labels)
         if use_loss_functional:
             loss = F.cross_entropy(outputs, labels)
-            hook.record_tensor_value("nll_loss", tensor_value=loss, inputs=[outputs, labels])
+            hook.record_tensor_value("nll_loss", tensor_value=loss)
         loss.backward()
         optimizer.step()
 

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -78,8 +78,8 @@ def test_register_loss_functional(out_dir):
     loss_tensor = trial.tensor("nll_loss_output_0")
 
     # Capture ['nll_loss_output_0']
-    assert len(trial.tensor_names()) == 3
-    assert len(loss_coll.tensor_names) == 3
+    assert len(trial.tensor_names()) == 1
+    assert len(loss_coll.tensor_names) == 1
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps
@@ -103,8 +103,8 @@ def test_register_loss_module(out_dir):
     loss_tensor = trial.tensor("CrossEntropyLoss_output_0")
 
     # Capture ['CrossEntropyLoss_input_0', 'CrossEntropyLoss_input_1', 'CrossEntropyLoss_output_0']
-    assert len(trial.tensor_names()) == 3
-    assert len(loss_coll.tensor_names) == 3
+    assert len(trial.tensor_names()) == 1
+    assert len(loss_coll.tensor_names) == 1
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -102,13 +102,9 @@ def test_register_loss_module(out_dir):
     loss_coll = trial.collection("losses")
     loss_tensor = trial.tensor("CrossEntropyLoss_output_0")
 
-    # Assert that we are not logging the inputs to loss block.
-    input_loss_tensors = trial.tensor_names(regex=".*[Ll]oss_input*")
-    assert len(input_loss_tensors) == 0
-
-    # Capture ['CrossEntropyLoss_output_0']
-    assert len(trial.tensor_names()) == 1
-    assert len(loss_coll.tensor_names) == 1
+    # Capture ['CrossEntropyLoss_input_0', 'CrossEntropyLoss_input_1', 'CrossEntropyLoss_output_0']
+    assert len(trial.tensor_names()) == 3
+    assert len(loss_coll.tensor_names) == 3
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps


### PR DESCRIPTION
### Description of changes:
The PR includes 

* the change which prevents logging the input tensors to the loss block.
We will only log the output of loss blocks.
* specify mode in ScalarCache to be used to retrieve the correct mode name and step number in write_scalars()
* increment global step number irrespective of which mode it is
* modifying save_scalar tests according to this change ([test output after this PR](https://gist.github.com/vandanavk/29a71ff38f95647fce91be55d562eaa1))

Frameworks tested:
- [x] MXNet
- [x] PyTorch
- [x] Tensorflow KerasHook
- [ ] TensorFlow SessionHook
- [x] XGBoost

Loss module metrics logged for SM metrics before this PR
```
cat 62064.json 
{"MetricName": "CrossEntropyLoss_input_0", "Value": -0.032386019825935364, "Timestamp": 1575495078851}
{"MetricName": "CrossEntropyLoss_input_1", "Value": 0.0, "Timestamp": 1575495078852}
{"MetricName": "CrossEntropyLoss_output_0", "Value": 2.299854040145874, "Timestamp": 1575495078852}
{"MetricName": "CrossEntropyLoss_input_0", "Value": -0.026646751910448074, "Timestamp": 1575495078860, "IterationNumber": 1}
{"MetricName": "CrossEntropyLoss_input_1", "Value": 0.0, "Timestamp": 1575495078860, "IterationNumber": 1}
{"MetricName": "CrossEntropyLoss_output_0", "Value": 2.188162088394165, "Timestamp": 1575495078860, "IterationNumber": 1}
{"MetricName": "CrossEntropyLoss_input_0", "Value": -0.012318896129727364, "Timestamp": 1575495078865, "IterationNumber": 2}
{"MetricName": "CrossEntropyLoss_input_1", "Value": 0.0, "Timestamp": 1575495078865, "IterationNumber": 2}
{"MetricName": "CrossEntropyLoss_output_0", "Value": 1.9457279443740845, "Timestamp": 1575495078865, "IterationNumber": 2}
{"MetricName": "CrossEntropyLoss_input_0", "Value": 0.020270144566893578, "Timestamp": 1575495078872, "IterationNumber": 3}
{"MetricName": "CrossEntropyLoss_input_1", "Value": 0.0, "Timestamp": 1575495078872, "IterationNumber": 3}
{"MetricName": "CrossEntropyLoss_output_0", "Value": 1.3983503580093384, "Timestamp": 1575495078872, "IterationNumber": 3}
{"MetricName": "CrossEntropyLoss_input_0", "Value": 0.14442947506904602, "Timestamp": 1575495078877, "IterationNumber": 4}
{"MetricName": "CrossEntropyLoss_input_1", "Value": 0.0, "Timestamp": 1575495078877, "IterationNumber": 4}
{"MetricName": "CrossEntropyLoss_output_0", "Value": 0.11063049733638763, "Timestamp": 1575495078877, "IterationNumber": 4}
```

Loss module - metrics logged for SM metrics with this PR
```
{"MetricName": "CrossEntropyLoss_output_0_GLOBAL", "Value": 2.33306884765625, "Timestamp": 1575672948.792166, "IterationNumber": 0}
{"MetricName": "CrossEntropyLoss_output_0_GLOBAL", "Value": 2.227065086364746, "Timestamp": 1575672948.800318, "IterationNumber": 1}
{"MetricName": "CrossEntropyLoss_output_0_GLOBAL", "Value": 2.0023903846740723, "Timestamp": 1575672948.804405, "IterationNumber": 2}
{"MetricName": "CrossEntropyLoss_output_0_GLOBAL", "Value": 1.5051748752593994, "Timestamp": 1575672948.8086379, "IterationNumber": 3}
{"MetricName": "CrossEntropyLoss_output_0_GLOBAL", "Value": 0.22368499636650085, "Timestamp": 1575672948.812764, "IterationNumber": 4}
```

Log for an entire epoch of training (using TRAIN and EVAL modes
https://gist.github.com/vandanavk/4c72140e55042e5bef310e1a5d31c2b4

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
