### PR TITLE
Revert "Skip logging the input tensors to the loss block. (#64)"

### DIFF
--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -154,9 +154,8 @@ class Hook(CallbackHook):
         # This overwhelms the logs; turn back on if you really need it
         # logger.debug("Processing the global step {0} for block {1}".format(self.step, block_name))
 
-        # Output input tensor if it is not a loss block
-        if isinstance(block, mx.gluon.loss.Loss) is False:
-            self._write_inputs(block_name, inputs)
+        # Output input tensor
+        self._write_inputs(block_name, inputs)
 
         # Output output tensors
         self._write_outputs(block_name, outputs)

--- a/tests/mxnet/test_hook_loss_collection.py
+++ b/tests/mxnet/test_hook_loss_collection.py
@@ -33,9 +33,6 @@ def test_loss_collection_default():
     loss_val = loss_tensor.value(step_num=1)
     assert len(loss_val) > 0
 
-    # Assert that we are not logging the inputs to loss block.
-    input_loss_tensors = tr.tensor_names(regex=".*loss._input*")
-    assert len(input_loss_tensors) == 0
     shutil.rmtree(out_dir)
 
 


### PR DESCRIPTION
This reverts commit 8ad99b613c6090da7b59b689bae453ccb245efa8.

### Description of changes:
@leleamol Please note the discussion in Chime and on this PR https://github.com/awslabs/sagemaker-debugger/pull/86 

We would like to able to save inputs to losses. It's just that we don't want these to go into losses collection. 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
