### PR TITLE
Fix ci to propogate failures

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -36,3 +36,5 @@ phases:
       - . $CODEBUILD_SRC_DIR/config/upload_on_end.sh
       - rm -rf $CODEBUILD_SRC_DIR/upload/$CURRENT_COMMIT_PATH
       - rm -rf $RULES_CODEBUILD_SRC_DIR/upload/$CURRENT_COMMIT_PATH
+      - if [ "$CODEBUILD_BUILD_SUCCEEDING" -eq 0 ]; then echo "ERROR BUILD FAILED " && exit 1 ; fi
+      - if [ "$CODEBUILD_BUILD_SUCCEEDING" -eq 1 ]; then echo "INFO BUILD SUCCEEDED !!! " ; fi

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -13,7 +13,7 @@ check_logs() {
 }
 
 run_for_framework() {
-    python -m pytest --duration=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
+    python -m pytest --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
 }
 
 export TF_CPP_MIN_LOG_LEVEL=1
@@ -23,8 +23,8 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest -v -W=ignore --duration=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
-python -m pytest -v -W=ignore --duration=50 --html=$REPORT_DIR/report_core.html --self-contained-html tests/core
+python -m pytest -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest -v -W=ignore --durations=50 --html=$REPORT_DIR/report_core.html --self-contained-html tests/core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
 set -ex
+set -o pipefail
 
 check_logs() {
   if grep -e "AssertionError" $1;

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -13,7 +13,7 @@ check_logs() {
 }
 
 run_for_framework() {
-    python -m pytest --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
+    python -m pytest --duration=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
 }
 
 export TF_CPP_MIN_LOG_LEVEL=1
@@ -23,8 +23,8 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest -v -W=ignore --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
-python -m pytest -v -W=ignore --html=$REPORT_DIR/report_core.html --self-contained-html tests/core
+python -m pytest -v -W=ignore --duration=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest -v -W=ignore --duration=50 --html=$REPORT_DIR/report_core.html --self-contained-html tests/core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost


### PR DESCRIPTION
### Description of changes:
- Added duration arg to pytest to capture long running test
- Checking and exiting with fail exit code if code build failed. Earlier CI was reporting success even if tests were failing.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
