### PR TITLE
[WIP] Support multiprocessing training

### DIFF
--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -1,6 +1,8 @@
 # Third Party
-import mxnet as mx
+# Standard Library
 import os
+
+import mxnet as mx
 
 # First Party
 from smdebug.core.collection import CollectionKeys

--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -70,7 +70,8 @@ class Hook(CallbackHook):
                 return f"worker_{hvd.rank()}"
         except (ModuleNotFoundError, ValueError, ImportError):
             pass
-        return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
+        worker_name = f"worker_" + os.getenv("SMDEBUG_WORKER_RANK", str(0))
+        return worker_name
 
     def _get_num_workers(self):
         try:

--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -1,5 +1,6 @@
 # Third Party
 import mxnet as mx
+import os
 
 # First Party
 from smdebug.core.collection import CollectionKeys
@@ -67,7 +68,7 @@ class Hook(CallbackHook):
                 return f"worker_{hvd.rank()}"
         except (ModuleNotFoundError, ValueError, ImportError):
             pass
-        return DEFAULT_WORKER_NAME
+        return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
 
     def _get_num_workers(self):
         try:
@@ -77,7 +78,7 @@ class Hook(CallbackHook):
                 return hvd.size()
         except (ModuleNotFoundError, ValueError, ImportError):
             pass
-        return 1
+        return int(os.getenv("SMDEBUG_NUM_WORKERS", 1))
 
     def _cleanup(self):
         # Write the gradients of the past step if the writer is still available.

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -1,4 +1,5 @@
 # Standard Library
+import os
 
 # Third Party
 import torch
@@ -70,7 +71,7 @@ class Hook(CallbackHook):
             except (ModuleNotFoundError, ValueError, ImportError):
                 pass
         # Return default
-        return 1
+        return int(os.getenv("SMDEBUG_NUM_WORKERS", 1))
 
     def _get_worker_name(self):
         """Check horovod and torch.distributed."""
@@ -87,8 +88,7 @@ class Hook(CallbackHook):
                     return f"worker_{hvd.rank()}"
             except (ModuleNotFoundError, ValueError, ImportError):
                 pass
-        # Return default
-        return DEFAULT_WORKER_NAME
+        return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
 
     def _log_params(self, module):
         module_name = module._get_name()

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -88,7 +88,8 @@ class Hook(CallbackHook):
                     return f"worker_{hvd.rank()}"
             except (ModuleNotFoundError, ValueError, ImportError):
                 pass
-        return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
+        worker_name = f"worker_" + os.getenv("SMDEBUG_WORKER_RANK", str(0))
+        return worker_name
 
     def _log_params(self, module):
         module_name = module._get_name()

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -175,7 +175,7 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.PARAMETER_SERVER:
             return get_worker_id_from_tf_config(self.tf_config_json)
         elif self.distribution_strategy == TFDistributionStrategy.NONE:
-            return DEFAULT_WORKER_NAME
+            return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
             raise NotImplementedError
 
@@ -220,7 +220,7 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.PARAMETER_SERVER:
             return get_num_workers_from_tf_config(self.tf_config_json)
         elif self.distribution_strategy == TFDistributionStrategy.NONE:
-            return 1
+            return int(os.getenv("SMDEBUG_NUM_WORKERS", 1))
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
             raise NotImplementedError
 

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -175,7 +175,8 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.PARAMETER_SERVER:
             return get_worker_id_from_tf_config(self.tf_config_json)
         elif self.distribution_strategy == TFDistributionStrategy.NONE:
-            return os.getenv("SMDEBUG_WORKER_NAME", DEFAULT_WORKER_NAME)
+            worker_name = f"worker_" + os.getenv("SMDEBUG_WORKER_RANK", str(0))
+            return worker_name
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
             raise NotImplementedError
 

--- a/tests/pytorch/test_distributed_training.py
+++ b/tests/pytorch/test_distributed_training.py
@@ -182,10 +182,11 @@ def test_run_net_distributed_save_one_worker():
     assert len(trial.workers()) == 1, f"trial.workers() = {trial.workers()}"
     assert len(trial.steps()) == 3, f"trial.steps() = {trial.steps()}"
 
+
 @pytest.mark.slow
 def test_run_net_distributed_multiproc_save_all_workers():
     size = 2
-    os.environ["SMDEBUG_NUM_WORKERS"] = '2'
+    os.environ["SMDEBUG_NUM_WORKERS"] = "2"
     processes = []
     for rank in range(size):
         os.environ["SMDEBUG_WORKER_NAME"] = f"worker_{rank}"
@@ -201,10 +202,11 @@ def test_run_net_distributed_multiproc_save_all_workers():
     assert len(trial.workers()) == 2, f"trial.workers() = {trial.workers()}"
     assert len(trial.steps()) == 3, f"trial.steps() = {trial.steps()}"
 
+
 @pytest.mark.slow
 def test_run_net_distributed_multiproc_save_one_worker():
     size = 2
-    os.environ["SMDEBUG_NUM_WORKERS"] = '2'
+    os.environ["SMDEBUG_NUM_WORKERS"] = "2"
     processes = []
     for rank in range(size):
         os.environ["SMDEBUG_WORKER_NAME"] = f"worker_{rank}"

--- a/tests/pytorch/test_distributed_training.py
+++ b/tests/pytorch/test_distributed_training.py
@@ -202,6 +202,9 @@ def test_run_net_distributed_multiproc_save_all_workers():
     assert len(trial.workers()) == 2, f"trial.workers() = {trial.workers()}"
     assert len(trial.steps()) == 3, f"trial.steps() = {trial.steps()}"
 
+    del os.environ["SMDEBUG_NUM_WORKERS"]
+    del os.environ["SMDEBUG_WORKER_NAME"]
+
 
 @pytest.mark.slow
 def test_run_net_distributed_multiproc_save_one_worker():
@@ -221,3 +224,6 @@ def test_run_net_distributed_multiproc_save_one_worker():
     trial = create_trial(path=out_dir)
     assert len(trial.workers()) == 1, f"trial.workers() = {trial.workers()}"
     assert len(trial.steps()) == 3, f"trial.steps() = {trial.steps()}"
+
+    del os.environ["SMDEBUG_NUM_WORKERS"]
+    del os.environ["SMDEBUG_WORKER_NAME"]

--- a/tests/pytorch/test_distributed_training.py
+++ b/tests/pytorch/test_distributed_training.py
@@ -90,12 +90,12 @@ def run(rank, size, include_workers="one", num_epochs=10, batch_size=128, num_ba
             loss = F.mse_loss(output, target)
             epoch_loss += loss.item()
             loss.backward()
-            if hasattr(dist, "is_initialized"):
+            if hasattr(dist, "is_initialized") and dist.is_initialized():
                 average_gradients(model)
             optimizer.step()
         # print(f"Rank {dist.get_rank()}, epoch {epoch}: {epoch_loss / num_batches}")
 
-    if hasattr(dist, "is_initialized"):
+    if hasattr(dist, "is_initialized") and dist.is_initialized():
         assert hook._get_worker_name() == f"worker_{dist.get_rank()}"
     # Race condition here where both workers attempt to move
     # /tmp/{out_dir}/END_OF_JOB.ts to {out_dir}/END_OF_JOB.ts


### PR DESCRIPTION
### Description of changes:

Training a model by splitting the dataset across multiple processes on the same machine is considered distributed training. While using SM Debugger along with a distributed training script, the user can provide the option to save data from all workers or just 1 worker (include_workers in the hook).

Currently, this option is used in the following scenarios:

Framework | Supports
-- | --
PyTorch | Horovod, torch.distributed
MXNet | Horovod
Tensorflow | MirroredWorkerStrategy
XGBoost | Rabit

The example in https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-python-sdk/dgl_kge uses Python multiprocessing for MXNet distributed training and torch.multiprocessing for PyTorch distributed training. Performing distributed training using multiprocessing is not yet handled by smdebug.

To handle this scenario, introducing env variables SMDEBUG_NUM_WORKERS and SMDEBUG_WORKER_NAME. User must specify these if they are using multiprocessing library in the training script. 

The other alternatives considered were:
1. Modify the DGL example for PyTorch to use torch.distributed. But as specified in https://github.com/awslabs/sagemaker-debugger/blob/2433316b76ac016dddac41e5003a51b7733f790b/tests/pytorch/test_distributed_training.py#L98, this may also lead to a race condition. Also, this would mean that training scripts using multiprocessing will not work.
2. Append the PID to the collection and event file names. Issue with this:- smdebug does not know how many processes are there, so in cases such as, trials waiting for all files to be present, there will be an issue.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
