### PR TITLE
Continuing rule execution in case we get TensorUnavailable exception

### DIFF
--- a/smdebug/rules/rule_invoker.py
+++ b/smdebug/rules/rule_invoker.py
@@ -1,6 +1,11 @@
 # First Party
 from smdebug.core.logger import get_logger
-from smdebug.exceptions import RuleEvaluationConditionMet, StepUnavailable, TensorUnavailableForStep
+from smdebug.exceptions import (
+    RuleEvaluationConditionMet,
+    StepUnavailable,
+    TensorUnavailable,
+    TensorUnavailableForStep,
+)
 
 logger = get_logger()
 
@@ -11,7 +16,7 @@ def invoke_rule(rule_obj, start_step=0, end_step=None, raise_eval_cond=False):
     while (end_step is None) or (step < end_step):
         try:
             rule_obj.invoke(step)
-        except (TensorUnavailableForStep, StepUnavailable) as e:
+        except (TensorUnavailableForStep, StepUnavailable, TensorUnavailable) as e:
             logger.debug(str(e))
         except RuleEvaluationConditionMet as e:
             if raise_eval_cond:


### PR DESCRIPTION
As rule might be looking for tensor which may be saved in future step,  in case we get TensorUnavailable , invoker will go on with executing rules.


### Description of changes:


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
