### PR TITLE
Fix scalar write to event file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -147,6 +147,7 @@ Note that `smd` import below translates to `import smdebug.{framework} as smd`.
 |`set_mode(mode)`| value of the enum `smd.modes` | Sets mode of the job, can be one of `smd.modes.TRAIN`, `smd.modes.EVAL`, `smd.modes.PREDICT` or `smd.modes.GLOBAL`. Refer [Modes](#modes) for more on that. |
 |`create_from_json_file(`<br/>`  json_file_path=None)` | `json_file_path (str)` | Takes the path of a file which holds the json configuration of the hook, and creates hook from that configuration. This is an optional parameter. <br/> If this is not passed it tries to get the file path from the value of the environment variable `SMDEBUG_CONFIG_FILE_PATH` and defaults to `/opt/ml/input/config/debughookconfig.json`. When training on SageMaker you do not have to specify any path because this is the default path that SageMaker writes the hook configuration to.
 |`close()` | - | Closes all files that are currently open by the hook |
+| `save_scalar(`<br/>`name, `<br/>`value, `<br/>`sm_metric=False)` | `name (str)` <br/> `value (float)` <br/> `sm_metric (bool)`| Saves a scalar value by the given name. Passing `sm_metric=True` flag also makes this scalar available as a SageMaker Metric to show up in SageMaker Studio. Note that when `sm_metric` is False, this scalar always resides only in your AWS account, but setting it to True saves the scalar also on AWS servers. The default value of `sm_metric` for this method is False. |
 
 ### TensorFlow specific Hook API
 Note that there are three types of Hooks in TensorFlow: SessionHook, EstimatorHook and KerasHook based on the TensorFlow interface being used for training. [This page](tensorflow.md) shows examples of each of these.
@@ -161,7 +162,6 @@ Note that there are three types of Hooks in TensorFlow: SessionHook, EstimatorHo
 | Method | Arguments | Behavior |
 | --- | --- | --- |
 | `register_block(block)` | `block (mx.gluon.Block)` | Calling this method applies the hook to the Gluon block representing the model, so SageMaker Debugger gets called by MXNet and can save the tensors required. |
-| `save_scalar(`<br/>`name, `<br/>`value, `<br/>`sm_metric=False)` | `name (str)` <br/> `value (float)` <br/> `sm_metric (bool)`| Saves a scalar value by the given name. Passing `sm_metric=True` flag also makes this scalar available as a SageMaker Metric to show up in SageMaker Studio. Note that when `sm_metric` is False, this scalar always resides only in your AWS account, but setting it to True saves the scalar also on AWS servers. The default value of `sm_metric` for this method is False. |
 
 ### PyTorch specific Hook API
 
@@ -170,7 +170,6 @@ Note that there are three types of Hooks in TensorFlow: SessionHook, EstimatorHo
 | --- | --- | --- |
 | `register_module(module)` | `module (torch.nn.Module)` | Calling this method applies the hook to the Torch Module representing the model, so SageMaker Debugger gets called by PyTorch and can save the tensors required. |
 | `register_loss(loss_module)` | `loss_module (torch.nn.modules.loss._Loss)` | Calling this method applies the hook to the Torch Module representing the loss, so SageMaker Debugger can save losses |
-| `save_scalar(`<br/>`name, `<br/>`value, `<br/>`sm_metric=False)` | `name (str)` <br/> `value (float)` <br/> `sm_metric (bool)`| Saves a scalar value by the given name. Passing `sm_metric=True` flag also makes this scalar available as a SageMaker Metric to show up in SageMaker Studio. Note that when `sm_metric` is False, this scalar always resides only in your AWS account, but setting it to True saves the scalar also on AWS servers. The default value of `sm_metric` for this method is False. |
 
 ---
 

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -354,8 +354,7 @@ class BaseHook:
             return
 
         # flush out sm_metric scalars to metrics file
-        if self.metrics_writer is not None:
-            self._write_scalars()
+        self._write_scalars()
 
         if self.writer is not None:
             self.writer.flush()

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -322,8 +322,7 @@ class TensorflowBaseHook(BaseHook):
             return
 
         # flush out sm_metric scalars to metrics file
-        if self.metrics_writer is not None:
-            self._write_scalars()
+        self._write_scalars()
 
         if self.writer is not None:
             self.writer.flush()
@@ -428,13 +427,6 @@ class TensorflowBaseHook(BaseHook):
         # since this is done for each variable at a time for keras, not checking if set already
         self.collection_manager.get(CollectionKeys.OPTIMIZER_VARIABLES).add_for_mode(
             optimizer_variables, ModeKeys.TRAIN
-        )
-
-    def save_scalar(self, name, value, sm_metric=False):
-        raise NotImplementedError(
-            "save_scalar not supported for Tensorflow. "
-            "Add the scalar to scalars or sm_metrics collection instead depending "
-            "on whether you want the scalar to show up as a SageMaker Metric. "
         )
 
     @staticmethod

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -339,6 +339,16 @@ class TensorflowBaseHook(BaseHook):
         for device in to_delete_writers:
             del self.writer_map[device]
 
+        to_delete_writers = []
+        # Delete all the tb writers
+        for mode, writer in self.tb_writers.items():
+            if writer is not None:
+                writer.flush()
+                writer.close()
+                to_delete_writers.append(mode)
+        for mode in to_delete_writers:
+            del self.tb_writers[mode]
+
     def _export_model(self):
         tb_writer = self._maybe_get_tb_writer()
         if tb_writer:

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -469,7 +469,9 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         # after first evaluation during training
         self.set_mode(mode)
 
-        self._close_writers()
+        # Write the gradients of the past step if the writer is still available.
+        if self.writer is not None:
+            self._close_writers()
         self._increment_step()
 
         if self.prepared_collections is False:

--- a/tests/core/test_hook_save_scalar.py
+++ b/tests/core/test_hook_save_scalar.py
@@ -343,7 +343,8 @@ def check_trials(out_dir, save_steps, saved_scalars=None):
             if eval_steps:  # need this check for bias and gradients
                 assert len(set(save_steps["EVAL"]) & set(eval_steps)) == len(save_steps["EVAL"])
     scalar_list = trial.tensor_names(regex="^scalar")
-    assert len(set(saved_scalars) & set(scalar_list)) == len(saved_scalars)
+    if saved_scalars:
+        assert len(set(saved_scalars) & set(scalar_list)) == len(saved_scalars)
 
 
 def verify_files(out_dir, save_config, saved_scalars=None):

--- a/tests/core/test_hook_save_scalar.py
+++ b/tests/core/test_hook_save_scalar.py
@@ -490,6 +490,7 @@ def helper_tensorflow_tests(use_keras, collection, save_config):
     verify_files(trial_dir, save_config, saved_scalars)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("use_keras", [True, False])
 @pytest.mark.parametrize("collection", [("all", ".*"), ("scalars", "^scalar")])
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes:
save_scalar wasn't writing events because of a check in close_Writers(). This PR contains a fix for that along with the corresponding fix to the unit test.
Apart from these changes, this PR contains 
1. doc update
2. additional tests for TF SessionHook and XGBoost.
3. enabling save_scalar for TF
4. init_step =-1 for Keras, adding a check in _on_any_batch_begin() (similar to the checks in pytorch and mxnet) to start writing after the 1st batch.
5. Fix to TF close_writers() to flush tb_writers -> Tested by checking the tensorboard output of test_tf_save_scalar(). screenshot of tb output pasted below.

Output:
PyTorch: Loss and custom scalar
![Screen Shot 2020-01-14 at 5 43 51 PM](https://user-images.githubusercontent.com/9017059/72398439-d5cc9d00-36f7-11ea-844a-0f7be52e72e4.png)

MXNet index file:
`{"meta": {"mode": "TRAIN", "mode_step": 0, "event_file_name": "events/000000000000/000000000000_worker_0.tfevents"}, "tensor_payload": [{"tensorname": "softmaxcrossentropyloss0_output_0", "start_idx": 0, "length": 275}, {"tensorname": "conv0_weight", "start_idx": 275, "length": 764}, {"tensorname": "gradient/conv0_weight", "start_idx": 1039, "length": 809}, {"tensorname": "conv0_bias", "start_idx": 1848, "length": 120}, {"tensorname": "gradient/conv0_bias", "start_idx": 1968, "length": 138}, {"tensorname": "conv1_weight", "start_idx": 2106, "length": 3621}, {"tensorname": "gradient/conv1_weight", "start_idx": 5727, "length": 3666}, {"tensorname": "conv1_bias", "start_idx": 9393, "length": 163}, {"tensorname": "gradient/conv1_bias", "start_idx": 9556, "length": 181}, {"tensorname": "dense0_weight", "start_idx": 9737, "length": 192136}, {"tensorname": "gradient/dense0_weight", "start_idx": 201873, "length": 192163}, {"tensorname": "dense0_bias", "start_idx": 394036, "length": 584}, {"tensorname": "gradient/dense0_bias", "start_idx": 394620, "length": 602}, {"tensorname": "dense1_weight", "start_idx": 395222, "length": 40454}, {"tensorname": "gradient/dense1_weight", "start_idx": 435676, "length": 40481}, {"tensorname": "dense1_bias", "start_idx": 476157, "length": 439}, {"tensorname": "gradient/dense1_bias", "start_idx": 476596, "length": 457}, {"tensorname": "dense2_weight", "start_idx": 477053, "length": 3489}, {"tensorname": "gradient/dense2_weight", "start_idx": 480542, "length": 3516}, {"tensorname": "dense2_bias", "start_idx": 484058, "length": 139}, {"tensorname": "gradient/dense2_bias", "start_idx": 484197, "length": 159}, {"tensorname": "scalar/mx_num_steps", "start_idx": 484356, "length": 122}, {"tensorname": "scalar/mx_before_train", "start_idx": 484478, "length": 128}]}`

![Screen Shot 2020-01-14 at 5 11 03 PM](https://user-images.githubusercontent.com/9017059/72482650-497fb000-37b3-11ea-8c2b-fcac78e53f9c.png)


Note: MXNet loss is not written to tensorboard as it is a vector. 

XGBoost:
![Screen Shot 2020-01-15 at 2 30 01 PM](https://user-images.githubusercontent.com/9017059/72477049-9065a980-37a3-11ea-8e1d-a976572c65e3.png)

TF Keras index file:
`{"meta": {"mode": "TRAIN", "mode_step": 0, "event_file_name": "events/000000000000/000000000000_worker_0.tfevents"}, "tensor_payload": [{"tensorname": "dense/weights/dense/kernel:0", "start_idx": 0, "length": 401590}, {"tensorname": "dense/weights/dense/bias:0", "start_idx": 401590, "length": 647}, {"tensorname": "dense_1/weights/dense_1/kernel:0", "start_idx": 402237, "length": 5308}, {"tensorname": "dense_1/weights/dense_1/bias:0", "start_idx": 407545, "length": 179}, {"tensorname": "dense_1/outputs/dense_1/Softmax:0", "start_idx": 407724, "length": 2400202}, {"tensorname": "training/gradients/dense/BiasAdd_grad/tuple/control_dependency_1:0", "start_idx": 2807926, "length": 727}, {"tensorname": "training/gradients/dense/MatMul_grad/tuple/control_dependency_1:0", "start_idx": 2808653, "length": 401702}, {"tensorname": "training/gradients/dense_1/BiasAdd_grad/tuple/control_dependency_1:0", "start_idx": 3210355, "length": 255}, {"tensorname": "training/gradients/dense_1/MatMul_grad/tuple/control_dependency_1:0", "start_idx": 3210610, "length": 5414}, {"tensorname": "batch", "start_idx": 3216024, "length": 94}, {"tensorname": "size", "start_idx": 3216118, "length": 92}, {"tensorname": "acc", "start_idx": 3216210, "length": 86}, {"tensorname": "loss", "start_idx": 3216296, "length": 88}, {"tensorname": "scalar/tf_keras_num_steps", "start_idx": 3216384, "length": 134}, {"tensorname": "scalar/tf_keras_before_train", "start_idx": 3216518, "length": 140}]}`

![Screen Shot 2020-01-15 at 5 31 24 PM](https://user-images.githubusercontent.com/9017059/72485552-ebf06100-37bc-11ea-978b-b2d868bf4189.png)


TF Session:
![Screen Shot 2020-01-15 at 6 26 50 PM](https://user-images.githubusercontent.com/9017059/72488022-a46dd300-37c4-11ea-9eec-a4a175034f78.png)





#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
