### PR TITLE
Pin the version of pip in buildspec

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -20,7 +20,7 @@ phases:
         - sudo apt-get update -qq -o=Dpkg::Use-Pty=0
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
-        - pip install -U pip
+        - pip install --upgrade pip==19.3.1
         - pip install -q pytest wheel pyYaml pytest-html keras==2.3.1 tensorflow==1.15.0 mxnet torch xgboost pre-commit tensorflow_datasets
         - pip uninstall -y boto3 botocore
 


### PR DESCRIPTION
### Description of changes:
the CI is currently broken because `pip install --upgrade pip` gets version 20. something. This causes issues when we use pip to install packages like tensorflow and mxnet. This PR pins the version of pip to 19.3.1

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
