### PR TITLE
tensor_names() returns only tensornames

### DIFF
--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -17,7 +17,8 @@ def helper_test_reductions(trial_dir, hook, save_raw_tensor):
 
     tr = create_trial(trial_dir)
     assert len(tr.tensor_names()) == 3, tr.tensor_names()
-    assert len(tr.tensor_names(step=0)) == 3, tr.tensor_names()
+    for step in tr.steps():
+        assert len(tr.tensor_names(step=step)) == 3, tr.tensor_names()
     for tname in tr.tensor_names():
         t = tr.tensor(tname)
         if tname in tr.tensor_names(collection="losses"):

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -17,6 +17,7 @@ def helper_test_reductions(trial_dir, hook, save_raw_tensor):
 
     tr = create_trial(trial_dir)
     assert len(tr.tensor_names()) == 3, tr.tensor_names()
+    assert len(tr.tensor_names(step=0)) == 3, tr.tensor_names()
     for tname in tr.tensor_names():
         t = tr.tensor(tname)
         if tname in tr.tensor_names(collection="losses"):


### PR DESCRIPTION
### Description of changes:
trial.tensor_names(step), was previously yielding incorrect and duplicate tensor names like these:

```
[smdebug/reductions/sum/gradients/MatMul_grad/tuple/control_dependency_1:0', 'smdebug/reductions/variance/foobar/weight1:0', 'smdebug/reductions/variance/gradients/MatMul_grad/tuple/control_dependency_1:0']
```

- Assigned formatted name to tensor_object.tensorname so that only the name of the tensor is saved
- removed shorthand for some variables to improve readability
- restructured code to improve readability 

### Testing
- Test the number of tensor_names output by `tensor_names(step)`

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available
#113 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
