### PR TITLE
Raise Error For Invalid Collection Config

### DIFF
--- a/smdebug/core/collection.py
+++ b/smdebug/core/collection.py
@@ -46,8 +46,33 @@ class CollectionKeys:
     TREES = "trees"
 
     @classmethod
-    def values(cls):
-        return [value for name, value in vars(cls).items() if name.isupper()]
+    def builtins(cls, framework=None):
+        default = [
+            CollectionKeys.DEFAULT,
+            CollectionKeys.ALL,
+            CollectionKeys.INPUTS,
+            CollectionKeys.OUTPUTS,
+            CollectionKeys.WEIGHTS,
+            CollectionKeys.GRADIENTS,
+            CollectionKeys.LOSSES,
+            CollectionKeys.BIASES,
+            CollectionKeys.SM_METRICS,
+            CollectionKeys.OPTIMIZER_VARIABLES,
+            CollectionKeys.TENSORFLOW_SUMMARIES,
+        ]
+        if framework is None:
+            return default
+        elif framework == "xgboost":
+            return [
+                CollectionKeys.HYPERPARAMETERS,
+                CollectionKeys.METRICS,
+                CollectionKeys.PREDICTIONS,
+                CollectionKeys.LABELS,
+                CollectionKeys.FEATURE_IMPORTANCE,
+                CollectionKeys.AVERAGE_SHAP,
+                CollectionKeys.FULL_SHAP,
+                CollectionKeys.TREES,
+            ] + default
 
 
 # Collection with summary objects instead of tensors

--- a/smdebug/core/collection.py
+++ b/smdebug/core/collection.py
@@ -45,6 +45,10 @@ class CollectionKeys:
     FULL_SHAP = "full_shap"
     TREES = "trees"
 
+    @classmethod
+    def values(cls):
+        return [value for name, value in vars(cls).items() if name.isupper()]
+
 
 # Collection with summary objects instead of tensors
 # so we don't create summaries or reductions of these

--- a/smdebug/core/collection.py
+++ b/smdebug/core/collection.py
@@ -34,45 +34,16 @@ class CollectionKeys:
 
     OPTIMIZER_VARIABLES = "optimizer_variables"
     TENSORFLOW_SUMMARIES = "tensorflow_summaries"
+    METRICS = "metrics"
 
     # XGBOOST
     HYPERPARAMETERS = "hyperparameters"
-    METRICS = "metrics"
     PREDICTIONS = "predictions"
     LABELS = "labels"
     FEATURE_IMPORTANCE = "feature_importance"
     AVERAGE_SHAP = "average_shap"
     FULL_SHAP = "full_shap"
     TREES = "trees"
-
-    @classmethod
-    def builtins(cls, framework=None):
-        default = [
-            CollectionKeys.DEFAULT,
-            CollectionKeys.ALL,
-            CollectionKeys.INPUTS,
-            CollectionKeys.OUTPUTS,
-            CollectionKeys.WEIGHTS,
-            CollectionKeys.GRADIENTS,
-            CollectionKeys.LOSSES,
-            CollectionKeys.BIASES,
-            CollectionKeys.SM_METRICS,
-            CollectionKeys.OPTIMIZER_VARIABLES,
-            CollectionKeys.TENSORFLOW_SUMMARIES,
-        ]
-        if framework is None:
-            return default
-        elif framework == "xgboost":
-            return [
-                CollectionKeys.HYPERPARAMETERS,
-                CollectionKeys.METRICS,
-                CollectionKeys.PREDICTIONS,
-                CollectionKeys.LABELS,
-                CollectionKeys.FEATURE_IMPORTANCE,
-                CollectionKeys.AVERAGE_SHAP,
-                CollectionKeys.FULL_SHAP,
-                CollectionKeys.TREES,
-            ] + default
 
 
 # Collection with summary objects instead of tensors
@@ -93,6 +64,50 @@ SM_METRIC_COLLECTIONS = {CollectionKeys.LOSSES, CollectionKeys.METRICS, Collecti
 NON_REDUCTION_COLLECTIONS = SCALAR_COLLECTIONS.union(SUMMARIES_COLLECTIONS)
 
 NON_HISTOGRAM_COLLECTIONS = SCALAR_COLLECTIONS.union(SUMMARIES_COLLECTIONS)
+
+DEFAULT_TF_COLLECTIONS = {
+    CollectionKeys.ALL,
+    CollectionKeys.DEFAULT,
+    CollectionKeys.WEIGHTS,
+    CollectionKeys.BIASES,
+    CollectionKeys.GRADIENTS,
+    CollectionKeys.LOSSES,
+    CollectionKeys.METRICS,
+    CollectionKeys.INPUTS,
+    CollectionKeys.OUTPUTS,
+    CollectionKeys.SM_METRICS,
+    CollectionKeys.OPTIMIZER_VARIABLES,
+}
+
+DEFAULT_PYTORCH_COLLECTIONS = {
+    CollectionKeys.ALL,
+    CollectionKeys.DEFAULT,
+    CollectionKeys.WEIGHTS,
+    CollectionKeys.BIASES,
+    CollectionKeys.GRADIENTS,
+    CollectionKeys.LOSSES,
+}
+
+DEFAULT_MXNET_COLLECTIONS = {
+    CollectionKeys.ALL,
+    CollectionKeys.DEFAULT,
+    CollectionKeys.WEIGHTS,
+    CollectionKeys.BIASES,
+    CollectionKeys.GRADIENTS,
+    CollectionKeys.LOSSES,
+}
+
+DEFAULT_XGBOOST_COLLECTIONS = {
+    CollectionKeys.ALL,
+    CollectionKeys.DEFAULT,
+    CollectionKeys.HYPERPARAMETERS,
+    CollectionKeys.PREDICTIONS,
+    CollectionKeys.LABELS,
+    CollectionKeys.FEATURE_IMPORTANCE,
+    CollectionKeys.AVERAGE_SHAP,
+    CollectionKeys.FULL_SHAP,
+    CollectionKeys.TREES,
+}
 
 
 class Collection:

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -312,13 +312,15 @@ class BaseHook:
             self.tensor_to_collections[tensor_name] = matched_colls
         return self.tensor_to_collections[tensor_name]
 
-    def _prepare_collections(self, builtin_collection_names=None):
+    @abstractmethod
+    def _get_default_collections(self):
+        pass
+
+    def _prepare_collections(self):
         """Populate collections_to_save and ensure every collection has
         a save_config and reduction_config."""
-        if builtin_collection_names is None:
-            builtin_collection_names = set(CollectionKeys.builtins())
         for c_name, c in self.collection_manager.get_collections().items():
-            if c_name not in builtin_collection_names:
+            if c_name not in self._get_default_collections():
                 if bool(c.include_regex) is False and bool(c.tensor_names) is False:
                     raise InvalidCollectionConfiguration(c_name)
             if c in self._collections_to_save:

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -312,10 +312,11 @@ class BaseHook:
             self.tensor_to_collections[tensor_name] = matched_colls
         return self.tensor_to_collections[tensor_name]
 
-    def _prepare_collections(self):
+    def _prepare_collections(self, builtin_collection_names=None):
         """Populate collections_to_save and ensure every collection has
         a save_config and reduction_config."""
-        builtin_collection_names = set(CollectionKeys.values())
+        if builtin_collection_names is None:
+            builtin_collection_names = set(CollectionKeys.builtins())
         for c_name, c in self.collection_manager.get_collections().items():
             if c_name not in builtin_collection_names:
                 if bool(c.include_regex) is False and bool(c.tensor_names) is False:

--- a/smdebug/exceptions.py
+++ b/smdebug/exceptions.py
@@ -2,6 +2,15 @@
 from smdebug.core.modes import ModeKeys as modes
 
 
+class InvalidCollectionConfiguration(Exception):
+    def __init__(self, c_name):
+        self.c_name = c_name
+
+    def __str__(self):
+        return f"Collection {self.c_name} has not been configured. \
+        Please fill in tensor_name or include_regex"
+
+
 class StepNotYetAvailable(Exception):
     def __init__(self, step, mode):
         self.step = step

--- a/smdebug/mxnet/collection.py
+++ b/smdebug/mxnet/collection.py
@@ -1,4 +1,5 @@
 # First Party
+from smdebug.core.collection import DEFAULT_MXNET_COLLECTIONS
 from smdebug.core.collection import Collection as BaseCollection
 from smdebug.core.collection import CollectionKeys
 from smdebug.core.collection_manager import CollectionManager as BaseCollectionManager
@@ -21,6 +22,8 @@ class CollectionManager(BaseCollectionManager):
             self._register_default_collections()
 
     def _register_default_collections(self):
+        for c in DEFAULT_MXNET_COLLECTIONS:
+            self.create_collection(c)
         self.get(CollectionKeys.WEIGHTS).include("^(?!gradient).*weight")
         self.get(CollectionKeys.BIASES).include("^(?!gradient).*bias")
         self.get(CollectionKeys.GRADIENTS).include("^gradient")

--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -2,7 +2,7 @@
 import mxnet as mx
 
 # First Party
-from smdebug.core.collection import CollectionKeys
+from smdebug.core.collection import DEFAULT_MXNET_COLLECTIONS, CollectionKeys
 from smdebug.core.hook import CallbackHook
 from smdebug.core.json_config import DEFAULT_WORKER_NAME
 from smdebug.mxnet.collection import CollectionManager
@@ -112,6 +112,9 @@ class Hook(CallbackHook):
                     f"Could not export model graph for tensorboard "
                     f"due to the mxnet exception: {e}"
                 )
+
+    def _get_default_collections(self):
+        return DEFAULT_MXNET_COLLECTIONS
 
     # This hook is invoked by trainer prior to running the forward pass.
     def forward_pre_hook(self, block, inputs):

--- a/smdebug/pytorch/collection.py
+++ b/smdebug/pytorch/collection.py
@@ -1,4 +1,5 @@
 # First Party
+from smdebug.core.collection import DEFAULT_PYTORCH_COLLECTIONS
 from smdebug.core.collection import Collection as BaseCollection
 from smdebug.core.collection import CollectionKeys
 from smdebug.core.collection_manager import CollectionManager as BaseCollectionManager
@@ -36,6 +37,8 @@ class CollectionManager(BaseCollectionManager):
             self._register_default_collections()
 
     def _register_default_collections(self):
+        for c in DEFAULT_PYTORCH_COLLECTIONS:
+            self.create_collection(c)
         self.get(CollectionKeys.WEIGHTS).include("^(?!gradient).*weight")
         self.get(CollectionKeys.BIASES).include("^(?!gradient).*bias")
         self.get(CollectionKeys.GRADIENTS).include("^gradient")

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -104,7 +104,6 @@ class Hook(CallbackHook):
         pass
 
     def _prepare_collections(self):
-        super()._prepare_collections()
         for coll in self.collection_manager.collections.values():
             for m, (include_inputs, include_outputs) in coll.modules.items():
                 module_name = self.module_maps[m]
@@ -112,6 +111,7 @@ class Hook(CallbackHook):
                     coll.include(module_name + "_input_")
                 if include_outputs:
                     coll.include(module_name + "_output_")
+        super()._prepare_collections()
 
     # This hook is invoked by trainer prior to running the forward pass.
     def forward_pre_hook(self, module, inputs):

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -5,7 +5,7 @@ import torch
 import torch.distributed as dist
 
 # First Party
-from smdebug.core.collection import CollectionKeys
+from smdebug.core.collection import DEFAULT_PYTORCH_COLLECTIONS, CollectionKeys
 from smdebug.core.hook import CallbackHook
 from smdebug.core.json_config import DEFAULT_WORKER_NAME
 from smdebug.pytorch.collection import CollectionManager
@@ -102,6 +102,9 @@ class Hook(CallbackHook):
 
     def _export_model(self):
         pass
+
+    def _get_default_collections(self):
+        return DEFAULT_PYTORCH_COLLECTIONS
 
     def _prepare_collections(self):
         for coll in self.collection_manager.collections.values():

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -7,6 +7,7 @@ from typing import List, Set
 from tensorflow.python.distribute.distribute_lib import _DefaultDistributionStrategy
 
 # First Party
+from smdebug.core.collection import DEFAULT_TF_COLLECTIONS
 from smdebug.core.config_constants import DEFAULT_WORKER_NAME
 from smdebug.core.hook import BaseHook
 from smdebug.core.modes import ModeKeys
@@ -178,6 +179,9 @@ class TensorflowBaseHook(BaseHook):
             return DEFAULT_WORKER_NAME
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
             raise NotImplementedError
+
+    def _get_default_collections(self):
+        return DEFAULT_TF_COLLECTIONS
 
     def export_collections(self):
         assert self._prepared_tensors[self.mode]

--- a/smdebug/tensorflow/collection.py
+++ b/smdebug/tensorflow/collection.py
@@ -9,6 +9,7 @@ except ImportError:
 from tensorflow.python.distribute import values
 
 # First Party
+from smdebug.core.collection import DEFAULT_TF_COLLECTIONS
 from smdebug.core.collection import Collection as BaseCollection
 from smdebug.core.collection import CollectionKeys
 from smdebug.core.collection_manager import CollectionManager as BaseCollectionManager
@@ -136,18 +137,7 @@ class CollectionManager(BaseCollectionManager):
     def __init__(self, collections=None, create_default=True):
         super().__init__(collections=collections)
         if create_default:
-            for n in [
-                CollectionKeys.DEFAULT,
-                CollectionKeys.WEIGHTS,
-                CollectionKeys.BIASES,
-                CollectionKeys.GRADIENTS,
-                CollectionKeys.LOSSES,
-                CollectionKeys.METRICS,
-                CollectionKeys.INPUTS,
-                CollectionKeys.OUTPUTS,
-                CollectionKeys.ALL,
-                CollectionKeys.SM_METRICS,
-            ]:
+            for n in DEFAULT_TF_COLLECTIONS:
                 self.create_collection(n)
             self.get(CollectionKeys.BIASES).include("bias")
 

--- a/smdebug/xgboost/collection.py
+++ b/smdebug/xgboost/collection.py
@@ -1,5 +1,5 @@
 # First Party
-from smdebug.core.collection import CollectionKeys
+from smdebug.core.collection import DEFAULT_XGBOOST_COLLECTIONS, CollectionKeys
 from smdebug.core.collection_manager import CollectionManager as BaseCollectionManager
 
 
@@ -10,6 +10,8 @@ class CollectionManager(BaseCollectionManager):
             self._register_default_collections()
 
     def _register_default_collections(self):
+        for c in DEFAULT_XGBOOST_COLLECTIONS:
+            self.create_collection(c)
         self.get(CollectionKeys.HYPERPARAMETERS).include("^hyperparameters/.*$")
         self.get(CollectionKeys.METRICS).include("^[a-zA-z]+-[a-zA-z0-9]+$")
         self.get(CollectionKeys.PREDICTIONS).include("^predictions$")

--- a/smdebug/xgboost/hook.py
+++ b/smdebug/xgboost/hook.py
@@ -144,6 +144,10 @@ class Hook(CallbackHook):
     def hook_from_config(cls, json_config_path=None):
         return cls.create_from_json_file(json_file_path=json_config_path)
 
+    def _prepare_collections(self):
+        builtin_collection_names = set(CollectionKeys.builtins(framework="xgboost"))
+        super()._prepare_collections(builtin_collection_names)
+
     def _is_last_step(self, env: CallbackEnv) -> bool:
         # env.iteration: current boosting round.
         # env.end_iteration: round # when training will end. this is always num_round + 1.  # noqa: E501

--- a/smdebug/xgboost/hook.py
+++ b/smdebug/xgboost/hook.py
@@ -9,7 +9,7 @@ from xgboost import DMatrix
 from xgboost.core import CallbackEnv
 
 # First Party
-from smdebug.core.collection import CollectionKeys
+from smdebug.core.collection import DEFAULT_XGBOOST_COLLECTIONS, CollectionKeys
 from smdebug.core.hook import CallbackHook
 from smdebug.core.json_config import create_hook_from_json_config
 from smdebug.core.save_config import SaveConfig
@@ -144,9 +144,11 @@ class Hook(CallbackHook):
     def hook_from_config(cls, json_config_path=None):
         return cls.create_from_json_file(json_file_path=json_config_path)
 
+    def _get_default_collections(self):
+        return DEFAULT_XGBOOST_COLLECTIONS
+
     def _prepare_collections(self):
-        builtin_collection_names = set(CollectionKeys.builtins(framework="xgboost"))
-        super()._prepare_collections(builtin_collection_names)
+        super()._prepare_collections()
 
     def _is_last_step(self, env: CallbackEnv) -> bool:
         # env.iteration: current boosting round.

--- a/tests/core/test_collections.py
+++ b/tests/core/test_collections.py
@@ -10,6 +10,7 @@ from smdebug.core.modes import ModeKeys
 from smdebug.core.reduction_config import ReductionConfig
 from smdebug.core.save_config import SaveConfig, SaveConfigMode
 from smdebug.core.utils import get_path_to_collections
+from smdebug.exceptions import InvalidCollectionConfiguration
 from smdebug.mxnet.hook import Hook
 
 
@@ -87,6 +88,7 @@ def test_collection_defaults_to_hook_config():
   """
     cm = CollectionManager()
     cm.create_collection("foo")
+    cm.get("foo").include_regex = "*"
     cm.get("foo").save_config = {ModeKeys.EVAL: SaveConfigMode(save_interval=20)}
 
     hook = Hook(
@@ -101,3 +103,28 @@ def test_collection_defaults_to_hook_config():
     hook._prepare_collections()
     assert cm.get("foo").save_config.mode_save_configs[ModeKeys.TRAIN].save_interval == 10
     assert cm.get("foo").reduction_config.save_raw_tensor is True
+
+
+def test_invalid_collection_config_exception():
+    cm = CollectionManager()
+    cm.create_collection("foo")
+
+    hook = Hook(
+        out_dir="/tmp/test_collections/" + str(datetime.datetime.now()),
+        save_config={ModeKeys.TRAIN: SaveConfigMode(save_interval=10)},
+        include_collections=["foo"],
+        reduction_config=ReductionConfig(save_raw_tensor=True),
+    )
+    hook.collection_manager = cm
+    try:
+        hook._prepare_collections()
+    except InvalidCollectionConfiguration:
+        pass
+    else:
+        assert False, "Invalid Collection Name did not raise error"
+
+    cm.get("foo").include_regex = "*"
+    try:
+        hook._prepare_collections()
+    except InvalidCollectionConfiguration:
+        assert False, "Valid Collection Name raised an error"


### PR DESCRIPTION
### Description of changes:
- Raise InvalidCollectionConfiguration exception if the customer has not correctly configured a collection
- Motivation behind the change, customers may make spelling mistakes or forget to correctly configure their custom collections.
- We want to enforce correct configurations so that they do not have to bear the cost of an entire job running with incorrect collection configurations
* Changes:
  * Added a new Exception class `InvalidCollectionConfiguration` in `smdebug/exceptions.py`
  * Added a check in `_prepare_collections` in `smdebug/core/hook.py`
  * Added a test `test_invalid_collection_config_exception`  in `tests/core/test_collections.py`

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
