### PR TITLE
Pytorch data parallel bug

### DIFF
--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -107,7 +107,7 @@ class Hook(CallbackHook):
         super()._prepare_collections()
         for coll in self.collection_manager.collections.values():
             for m, (include_inputs, include_outputs) in coll.modules.items():
-                module_name = self.module_maps[m]
+                module_name = self.module_maps[id(m)]
                 if include_inputs:
                     coll.include(module_name + "_input_")
                 if include_outputs:
@@ -150,7 +150,7 @@ class Hook(CallbackHook):
         if not self._get_collections_to_save_for_step():
             return
 
-        module_name = self.module_maps[module]
+        module_name = self.module_maps[id(module)]
         # This overwhelms the logs; turn back on if you really need it
         # logger.debug("Processing the global step {0} for module {1}".format(self.step, module_name))
 
@@ -206,8 +206,8 @@ class Hook(CallbackHook):
         # Create a mapping from modules to their names
         for name, submodule in module.named_modules():
             assert submodule not in self.module_maps, f"Don't register module={module} twice"
-            self.module_maps[submodule] = name
-        self.module_maps[module] = module._get_name()
+            self.module_maps[id(submodule)] = name
+        self.module_maps[id(module)] = module._get_name()
 
         # Use `forward_pre_hook` for the entire net
         module.register_forward_pre_hook(self.forward_pre_hook)
@@ -230,7 +230,7 @@ class Hook(CallbackHook):
         )
         # Register the module in self.module_maps
         name = loss_module._get_name()
-        self.module_maps[loss_module] = name
+        self.module_maps[id(loss_module)] = name
         # Add a callback to the forward pass
         loss_module.register_forward_hook(self.forward_hook)
         self.has_registered_loss_module = True

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -107,7 +107,7 @@ class Hook(CallbackHook):
         super()._prepare_collections()
         for coll in self.collection_manager.collections.values():
             for m, (include_inputs, include_outputs) in coll.modules.items():
-                module_name = self.module_maps[id(m)]
+                module_name = self.module_maps[m]
                 if include_inputs:
                     coll.include(module_name + "_input_")
                 if include_outputs:
@@ -150,7 +150,12 @@ class Hook(CallbackHook):
         if not self._get_collections_to_save_for_step():
             return
 
-        module_name = self.module_maps[id(module)]
+        if module not in self.module_maps:
+            if isinstance(module, torch.nn.modules.loss._Loss):
+                self.register_loss(module)
+            else:
+                self.register_module(module)
+        module_name = self.module_maps[module]
         # This overwhelms the logs; turn back on if you really need it
         # logger.debug("Processing the global step {0} for module {1}".format(self.step, module_name))
 
@@ -206,8 +211,8 @@ class Hook(CallbackHook):
         # Create a mapping from modules to their names
         for name, submodule in module.named_modules():
             assert submodule not in self.module_maps, f"Don't register module={module} twice"
-            self.module_maps[id(submodule)] = name
-        self.module_maps[id(module)] = module._get_name()
+            self.module_maps[submodule] = name
+        self.module_maps[module] = module._get_name()
 
         # Use `forward_pre_hook` for the entire net
         module.register_forward_pre_hook(self.forward_pre_hook)
@@ -230,7 +235,7 @@ class Hook(CallbackHook):
         )
         # Register the module in self.module_maps
         name = loss_module._get_name()
-        self.module_maps[id(loss_module)] = name
+        self.module_maps[loss_module] = name
         # Add a callback to the forward pass
         loss_module.register_forward_hook(self.forward_hook)
         self.has_registered_loss_module = True

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -47,7 +47,7 @@ class Hook(CallbackHook):
         )
         # mapping of module objects to their names,
         # useful in forward hook for logging input/output of modules
-        self.module_maps = dict()
+        self.module_set = set()
 
         self.has_registered_module = False
         self.has_registered_loss_module = False
@@ -107,7 +107,7 @@ class Hook(CallbackHook):
         super()._prepare_collections()
         for coll in self.collection_manager.collections.values():
             for m, (include_inputs, include_outputs) in coll.modules.items():
-                module_name = self.module_maps[m]
+                module_name = m._module_name
                 if include_inputs:
                     coll.include(module_name + "_input_")
                 if include_outputs:
@@ -150,12 +150,7 @@ class Hook(CallbackHook):
         if not self._get_collections_to_save_for_step():
             return
 
-        if module not in self.module_maps:
-            if isinstance(module, torch.nn.modules.loss._Loss):
-                self.register_loss(module)
-            else:
-                self.register_module(module)
-        module_name = self.module_maps[module]
+        module_name = module._module_name
         # This overwhelms the logs; turn back on if you really need it
         # logger.debug("Processing the global step {0} for module {1}".format(self.step, module_name))
 
@@ -208,11 +203,15 @@ class Hook(CallbackHook):
                 f"Module type {module.__class__.__name__} must be type torch.nn.Module"
             )
 
-        # Create a mapping from modules to their names
+        # Create an attribute and store the module name in the object
+        # So that it is available in the forward hook.
+
         for name, submodule in module.named_modules():
-            assert submodule not in self.module_maps, f"Don't register module={module} twice"
-            self.module_maps[submodule] = name
-        self.module_maps[module] = module._get_name()
+            assert submodule not in self.module_set, f"Don't register module={module} twice"
+            submodule._module_name = name
+            self.module_set.add(submodule)
+        self.module_set.add(module)
+        module._module_name = module._get_name()
 
         # Use `forward_pre_hook` for the entire net
         module.register_forward_pre_hook(self.forward_pre_hook)
@@ -233,9 +232,7 @@ class Hook(CallbackHook):
             f"loss_module={loss_module} must be subclass of `torch.nn.modules.loss._Loss`, "
             f"but has class hierarchy {type.mro(type(loss_module))}"
         )
-        # Register the module in self.module_maps
-        name = loss_module._get_name()
-        self.module_maps[loss_module] = name
+        loss_module._module_name = loss_module._get_name()
         # Add a callback to the forward pass
         loss_module.register_forward_hook(self.forward_hook)
         self.has_registered_loss_module = True

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -210,8 +210,8 @@ class Hook(CallbackHook):
             assert submodule not in self.module_set, f"Don't register module={module} twice"
             submodule._module_name = name
             self.module_set.add(submodule)
-        self.module_set.add(module)
         module._module_name = module._get_name()
+        self.module_set.add(module)
 
         # Use `forward_pre_hook` for the entire net
         module.register_forward_pre_hook(self.forward_pre_hook)
@@ -233,6 +233,7 @@ class Hook(CallbackHook):
             f"but has class hierarchy {type.mro(type(loss_module))}"
         )
         loss_module._module_name = loss_module._get_name()
+        self.module_set.add(loss_module)
         # Add a callback to the forward pass
         loss_module.register_forward_hook(self.forward_hook)
         self.has_registered_loss_module = True

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -40,9 +40,8 @@ def get_dataloader():
 def test_data_parallel():
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = Net()
-    if device == "cpu":
-        model = model.to(device)
-    else:
+    model = model.to(device)
+    if device == "cuda":
         model = DataParallel(model)
     epochs = 10
     optimizer = Adam(model.parameters(), lr=0.0001)

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -1,0 +1,75 @@
+# Standard Library
+import shutil
+
+# Third Party
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DataParallel
+from torch.optim import Adam
+from torch.utils.data import DataLoader, TensorDataset
+
+# First Party
+import smdebug.pytorch as smd
+from smdebug.trials import create_trial
+
+out_dir = "/tmp/run"
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.fc = nn.Linear(20, 10)
+
+    def forward(self, x):
+        output = self.fc(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def get_dataloader():
+    data = torch.randn([100, 20], requires_grad=True)
+    target = torch.from_numpy(np.random.randint(0, 9, (100)))
+    data = data.float()
+    dataset = TensorDataset(data, target)
+    dataloader = DataLoader(dataset, batch_size=10)
+    return dataloader
+
+
+def test_data_parallel():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = Net()
+    if device == "cpu":
+        model = model.to(device)
+    else:
+        model = DataParallel(model)
+    epochs = 10
+    optimizer = Adam(model.parameters(), lr=0.0001)
+
+    dataloader = get_dataloader()
+
+    shutil.rmtree(out_dir, ignore_errors=True)
+
+    hook = smd.Hook(
+        out_dir=out_dir,
+        save_config=smd.SaveConfig(save_steps=[0, 1, 5]),
+        save_all=True,
+        include_workers="one",
+    )
+
+    hook.register_module(model)
+
+    for i in range(epochs):
+        model.train()
+
+        for data, label in dataloader:
+            data, label = data.to(device), label.to(device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = F.nll_loss(output, label)
+            loss.backward()
+            optimizer.step()
+
+    trial = create_trial(out_dir)
+    assert len(trial.tensor_names()) == 1

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -38,4 +38,6 @@ def test_data_parallel():
     if device == "cpu":
         assert len(trial.tensor_names()) == 36
     else:
-        assert len(trial.tensor_names()) == 1
+        assert len(trial.tensor_names()) > 36
+
+    shutil.rmtree(out_dir, ignore_errors=True)

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -4,8 +4,8 @@ import shutil
 # Third Party
 import numpy as np
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+from tests.pytorch.utils import Net
 from torch.nn.parallel import DataParallel
 from torch.optim import Adam
 from torch.utils.data import DataLoader, TensorDataset
@@ -15,17 +15,6 @@ import smdebug.pytorch as smd
 from smdebug.trials import create_trial
 
 out_dir = "/tmp/run"
-
-
-class Net(nn.Module):
-    def __init__(self):
-        super(Net, self).__init__()
-        self.fc = nn.Linear(20, 10)
-
-    def forward(self, x):
-        output = self.fc(x)
-        output = F.log_softmax(x, dim=1)
-        return output
 
 
 def get_dataloader():


### PR DESCRIPTION
### Description of changes:
- Bug has been documented [here](https://answers.amazon.com/questions/93236)
- Removed the module_map datastructure and replaced it with a module_set which prevents the registration of modules more than once
- Assigned module names to the module objects themselves so that the attribute value is available across devices.
- This is a partial fix that allows customers to use the Pytorch Dataparallel construct with encountering bugs, next steps would be the creation a separate collection/index/event files for each worker

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
