### PR TITLE
Fixing the CI: Generate a random S3 path so that tests can run concurrently.

### DIFF
--- a/tests/core/test_training_end.py
+++ b/tests/core/test_training_end.py
@@ -1,5 +1,6 @@
 # Standard Library
 import shutil
+import uuid
 
 # Third Party
 import pytest
@@ -30,7 +31,8 @@ def test_negative_local_training_end():
 
 @pytest.mark.slow  # 0:04 to run
 def test_s3_training_end():
-    s3dir = "s3://smdebugcodebuildtest/training_end_test_dir"
+    s3key = str(uuid.uuid4())
+    s3dir = f"s3://smdebugcodebuildtest/ok_to_delete_{s3key}"
     _, bucket, key = is_s3(s3dir)
     f = TSAccessS3(bucket_name=bucket, key_name=key)
     f.close()


### PR DESCRIPTION
### Description of changes:
The test_training_end.py runs with a static S3 path.
It writes a "end of training" file in S3 and verifies whether it exists.

However, it does this operation with static S3 path. When this test is run concurrently (in parallel CI builds), the test fails.

This change fixes this issue by generating a random 'key' or trial_prefix within S3 bucket which will get deleted after successful execution.

I have prefixed the uuid with 'ok_to_delete' string so that we can clean them up later if such keys happen to linger due to occasional CI failures.


#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
