### PR TITLE
[TRSL-522] log errors to /opt/ml/output/failure

### DIFF
--- a/smdebug/core/logger.py
+++ b/smdebug/core/logger.py
@@ -60,6 +60,16 @@ def get_logger(name="smdebug"):
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
+        if "SM_TRAINING_ENV" in os.environ:
+            # TRSL-522
+            sm_log_fh = logging.FileHandler(
+                os.environ.get("SMDEBUG_SM_LOGFILE", "/opt/ml/output/failure")
+            )
+            sm_log_fh.setLevel(
+                logging.getLevelName((os.environ.get("SMDEBUG_SM_LOGLEVEL", "INFO")))
+            )
+            logger.addHandler(sm_log_fh)
+
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setFormatter(log_formatter)
 

--- a/smdebug/exceptions.py
+++ b/smdebug/exceptions.py
@@ -1,45 +1,57 @@
 # First Party
+from smdebug.core.logger import get_logger
 from smdebug.core.modes import ModeKeys as modes
 
 
-class InvalidCollectionConfiguration(Exception):
+class SMDebugError(Exception):
+    def __init__(self):
+        logger = get_logger("exceptions")
+        logger.error("%s: %s", self.__class__.__name__, str(self))
+        for h in logger.handlers:
+            h.flush()
+
+
+class InvalidCollectionConfiguration(SMDebugError):
     def __init__(self, c_name):
         self.c_name = c_name
+        super().__init__()
 
     def __str__(self):
-        return f"Collection {self.c_name} has not been configured. \
-        Please fill in tensor_name or include_regex"
+        return f"Collection {self.c_name} has not been configured. Please fill in tensor_name or include_regex"
 
 
-class StepNotYetAvailable(Exception):
+class StepNotYetAvailable(SMDebugError):
     def __init__(self, step, mode):
         self.step = step
         self.mode = mode
+        super().__init__()
 
     def __str__(self):
         return "Step {} of mode {} not yet available".format(self.step, self.mode.name)
 
 
-class MissingCollectionFiles(Exception):
+class MissingCollectionFiles(SMDebugError):
     def __init__(self):
-        pass
+        super().__init__()
 
     def __str__(self):
         return "Training job has ended. All the collection files could not be loaded"
 
 
-class IndexReaderException(Exception):
+class IndexReaderException(SMDebugError):
     def __init__(self, message):
         self.message = message
+        super().__init__()
 
     def __str__(self):
         return self.message
 
 
-class StepUnavailable(Exception):
+class StepUnavailable(SMDebugError):
     def __init__(self, step, mode):
         self.step = step
         self.mode = mode
+        super().__init__()
 
     def __str__(self):
         return "Step {} of mode {} is not available as it was not saved".format(
@@ -47,12 +59,13 @@ class StepUnavailable(Exception):
         )
 
 
-class TensorUnavailableForStep(Exception):
+class TensorUnavailableForStep(SMDebugError):
     def __init__(self, tname, step, mode=modes.GLOBAL, has_reductions=False):
         self.step = step
         self.mode = mode
         self.tname = tname
         self.has_reductions = has_reductions
+        super().__init__()
 
     def __str__(self):
         msg = (
@@ -68,23 +81,25 @@ class TensorUnavailableForStep(Exception):
         return msg
 
 
-class TensorUnavailable(Exception):
+class TensorUnavailable(SMDebugError):
     def __init__(self, tname):
         self.tname = tname
+        super().__init__()
 
     def __str__(self):
         return "Tensor {} was not saved.".format(self.tname)
 
 
-class InvalidWorker(Exception):
+class InvalidWorker(SMDebugError):
     def __init__(self, worker):
         self.worker = worker
+        super().__init__()
 
     def __str__(self):
         return "Invalid Worker: {}".format(self.worker)
 
 
-class NoMoreData(Exception):
+class NoMoreData(SMDebugError):
     def __init__(self, step, mode, last_step):
         self.step = step
         self.mode = mode
@@ -96,15 +111,17 @@ class NoMoreData(Exception):
                 self.step, self.mode.name, self.last_step
             )
         )
+        super().__init__()
 
     def __str__(self):
         return self.msg
 
 
-class RuleEvaluationConditionMet(Exception):
+class RuleEvaluationConditionMet(SMDebugError):
     def __init__(self, rule_name, step):
         self.rule_name = rule_name
         self.step = step
+        super().__init__()
 
     def __str__(self):
         return "Evaluation of the rule {} at step {} resulted in the condition being met".format(
@@ -112,10 +129,11 @@ class RuleEvaluationConditionMet(Exception):
         )
 
 
-class InsufficientInformationForRuleInvocation(Exception):
+class InsufficientInformationForRuleInvocation(SMDebugError):
     def __init__(self, rule_name, message):
         self.rule_name = rule_name
         self.message = mesage
+        super().__init__()
 
     def __str__(self):
         return "Insufficient information to invoke rule {}: {}".format(self.rule_name, self.message)

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -1,0 +1,26 @@
+# Standard Library
+import os
+import tempfile
+
+# First Party
+from smdebug.exceptions import InvalidCollectionConfiguration
+
+# Local
+from ..util import EnvManager
+
+
+def test_exception_logging():
+    with EnvManager("SM_TRAINING_ENV", "1"), tempfile.NamedTemporaryFile(
+        mode="w+"
+    ) as tmp, EnvManager("SMDEBUG_SM_LOGFILE", tmp.name):
+        try:
+            raise InvalidCollectionConfiguration("ra")
+        except Exception as e:
+            pass
+        assert os.path.exists(tmp.name)
+        tmp.flush()
+        tmp.seek(0, 0)
+        content = tmp.read()
+        print("content: ")
+        print(content)
+        assert "InvalidCollectionConfiguration" in content

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,21 @@
+# Standard Library
+import os
+
+
+class EnvManager(object):
+    """Environment variable setter and unsetter via with idiom"""
+
+    def __init__(self, key, val):
+        self._key = key
+        self._next_val = val
+        self._prev_val = None
+
+    def __enter__(self):
+        self._prev_val = os.environ.get(self._key)
+        os.environ[self._key] = self._next_val
+
+    def __exit__(self, ptype, value, trace):
+        if self._prev_val:
+            os.environ[self._key] = self._prev_val
+        else:
+            del os.environ[self._key]


### PR DESCRIPTION
### Description of changes:

When running in SGM, we want to log the errors in  /opt/ml/output/failure so we can have metrics and alarms.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

TRSL-522

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
