### PR TITLE
Update test_keras.py to support TF 2.2

### DIFF
--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -25,6 +25,13 @@ from smdebug.tensorflow import ReductionConfig, SaveConfig
 
 
 def is_tf_2_2():
+    """
+    TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections.
+    where 'batch' is the batch number and size is the batch size.
+    But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total
+    number of tensor_names emitted by 1.
+    :return: bool
+    """
     if search("2.2..", tf.__version__):
         return True
     return False

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -6,6 +6,8 @@ before pushing to master.
 This was tested with TensorFlow 2.1, by running
 `python tests/tensorflow2/test_keras.py` from the main directory.
 """
+# Standard Library
+from re import search
 
 # Third Party
 import pytest
@@ -20,6 +22,12 @@ from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.exceptions import TensorUnavailableForStep
 from smdebug.tensorflow import ReductionConfig, SaveConfig
+
+
+def is_tf_2_2():
+    if search("2.2..", tf.__version__):
+        return True
+    return False
 
 
 def helper_keras_fit(
@@ -108,15 +116,19 @@ def test_keras_fit(out_dir, tf_eager_mode, saveall):
     # can't save gradients in TF 2.x eager mode
     if saveall:  # save losses, metrics, weights, biases
         if tf_eager_mode:
-            assert len(trial.tensor_names()) == 8
+            assert len(trial.tensor_names()) == 7 if is_tf_2_2() else 8
         else:
             assert len(trial.tensor_names()) == 21
         assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     else:  # save the default losses and metrics
-        assert len(trial.tensor_names()) == 4
+        assert len(trial.tensor_names()) == 3 if is_tf_2_2() and tf_eager_mode else 4
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 3
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        if is_tf_2_2() and tf_eager_mode
+        else 3
+    )
 
 
 @pytest.mark.slow
@@ -211,7 +223,7 @@ def test_clash_with_tb_callback(out_dir, tf_eager_mode):
         eager=tf_eager_mode,
     )
     tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.tensor_names()) == 8
+    assert len(tr.tensor_names()) == 7 if is_tf_2_2() else 8
 
 
 @pytest.mark.slow
@@ -234,11 +246,15 @@ def test_weights_collections(out_dir, tf_eager_mode):
 
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
-    assert len(trial.tensor_names()) == 6
+    assert len(trial.tensor_names()) == 5 if is_tf_2_2() and tf_eager_mode else 6
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 3
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        if is_tf_2_2() and tf_eager_mode
+        else 3
+    )
 
 
 @pytest.mark.slow
@@ -264,7 +280,7 @@ def test_include_collections(out_dir, tf_eager_mode):
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
     if tf_eager_mode:
-        assert len(trial.tensor_names()) == 8
+        assert len(trial.tensor_names()) == 7 if is_tf_2_2() else 8
     else:
         assert len(trial.tensor_names()) == 18
         assert len(trial.tensor_names(collection=CollectionKeys.GRADIENTS)) == 4
@@ -272,7 +288,11 @@ def test_include_collections(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 3
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        if is_tf_2_2() and tf_eager_mode
+        else 3
+    )
 
 
 @pytest.mark.slow
@@ -286,8 +306,12 @@ def test_hook_from_json(out_dir, tf_eager_mode, monkeypatch):
 
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
-    assert len(trial.tensor_names()) == 6
+    assert len(trial.tensor_names()) == 5 if is_tf_2_2() and tf_eager_mode else 6
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 3
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        if is_tf_2_2() and tf_eager_mode
+        else 3
+    )


### PR DESCRIPTION
### Description of changes:
- TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections where 'batch' is the batch number and size is the batch size.
- But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total number of tensor_names emitted by 1.
- This PR updates the assert statements to handle this behavior.
- The reason for this change in behavior has not been included in the change-logs of the two TF 2.2 release candidates

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
