### PR TITLE
Unambiguous Initialization of Parent Classes

### DIFF
--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -39,7 +39,8 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         save_all=False,
         include_workers="one",
     ):
-        super().__init__(
+        TensorflowBaseHook.__init__(
+            self,
             out_dir=out_dir,
             export_tensorboard=export_tensorboard,
             tensorboard_dir=tensorboard_dir,
@@ -52,6 +53,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             save_all=save_all,
             include_workers=include_workers,
         )
+        tf.keras.callbacks.Callback.__init__(self)
         self.tensor_refs_to_save_this_step = set()
         self._fetches_added = set()
         self.callable_cache = CallableCache()


### PR DESCRIPTION
### Description of changes:
- encountered a bug while testing the tensorflow 2.2 release candidate, where the member variables of the parent class were unavailable from the child class.
- this code change will make the initialization of the parent classes unambiguous 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
