### PR TITLE
Register If Tensor Requires Gradients

### DIFF
--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -183,7 +183,8 @@ class Hook(CallbackHook):
         params = module.named_parameters()
         for name, param in params:
             pname = module._get_name() + "_" + name
-            param.register_hook(self.backward_hook(pname))
+            if param.requires_grad:
+                param.register_hook(self.backward_hook(pname))
 
     def _closure_for_registering_forward_hook(self, module):
         """Lambda functions don't work here."""

--- a/tests/pytorch/test_training_with_no_grad_updates.py
+++ b/tests/pytorch/test_training_with_no_grad_updates.py
@@ -1,0 +1,112 @@
+# Standard Library
+import argparse
+import os
+
+# Third Party
+import torch
+from torch.utils.data import DataLoader, IterableDataset
+
+
+class TestDataset(IterableDataset):
+    """Test dataset to generate random samples."""
+
+    def __init__(self, num_items, num_samples):
+        self.num_items = num_items
+        self.num_samples = num_samples
+
+    def __iter__(self):
+        def gen_rand(num_samples):
+            num = 0
+            while num < num_samples:
+                yield torch.randint(self.num_items, size=(1,)).item()
+                num += 1
+
+        return gen_rand(self.num_samples)
+
+
+class TestModel(torch.nn.Module):
+    """Test model that tries to learn the mapping between index and embedding."""
+
+    def __init__(self, embedding_size):
+        super(TestModel, self).__init__()
+        self.fc = torch.nn.Sequential(
+            torch.nn.Linear(1, embedding_size, bias=True), torch.nn.Tanh()
+        )
+        self.fc.apply(init_weights("xavier"))
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+def get_device():
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def init_weights(method):
+    def _init_weights(m):
+        if type(m) == torch.nn.Linear:
+            if method == "xavier":
+                torch.nn.init.xavier_uniform_(m.weight)
+            elif method == "he":
+                torch.nn.init.kaiming_uniform_(m.weight)
+            else:
+                raise Exception("Unsupported initialization method: {}".format(method))
+
+    return _init_weights
+
+
+def do_training(args):
+    # Generate a matrix of fake random embeddings.
+    N = 1000
+    EMBEDDING_SIZE = 768
+    embedding_matrix = torch.nn.Embedding.from_pretrained(
+        torch.randn(N, EMBEDDING_SIZE, dtype=torch.float32)
+    )
+    embedding_matrix = embedding_matrix.to(get_device())
+
+    # Setup dataset + data loader.
+    BATCH_SIZE = 64
+    NUM_BATCHES = 100
+    train_dataset = TestDataset(num_items=N, num_samples=NUM_BATCHES * BATCH_SIZE)
+    train_loader = DataLoader(train_dataset, batch_size=BATCH_SIZE, shuffle=False)
+
+    # Setup model.
+    model = TestModel(embedding_size=EMBEDDING_SIZE).to(get_device())
+
+    # Setup criterion.
+    criterion = torch.nn.CosineEmbeddingLoss()
+
+    # Setup optimizer.
+    optimizer = torch.optim.Adam(model.parameters())
+
+    # Training loop.
+    for batch in train_loader:
+        # Lookup items in the embedding matrix.
+        item_ids = batch
+        lookup_embeddings = embedding_matrix(item_ids.to(embedding_matrix.weight.device))
+        # Forward pass.
+        x = batch.float().to(get_device()).view(-1, 1)
+        output_embeddings = model(x)
+        # Calculate loss.
+        labels = torch.ones(
+            lookup_embeddings.shape[0], dtype=torch.int32, device=embedding_matrix.weight.device
+        )
+        loss = criterion(output_embeddings, lookup_embeddings, labels)
+        print("Loss: {}".format(loss))
+        # Zero out gradients.
+        optimizer.zero_grad()
+        # Do backwards pass.
+        loss.backward()
+        # Update model.
+        optimizer.step()
+
+    # Save out the final model.
+    torch.save(model.state_dict(), os.path.join(args.model_dir, "model.pth"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--train", type=str, default=os.environ.get("SM_CHANNEL_TRAIN"))
+    parser.add_argument("--model_dir", type=str, default=os.environ.get("SM_MODEL_DIR"))
+    args = parser.parse_args()
+    do_training(args)

--- a/tests/pytorch/test_training_with_no_grad_updates.py
+++ b/tests/pytorch/test_training_with_no_grad_updates.py
@@ -1,6 +1,4 @@
 # Standard Library
-import argparse
-import os
 
 # Third Party
 import torch
@@ -100,13 +98,6 @@ def do_training(args):
         # Update model.
         optimizer.step()
 
-    # Save out the final model.
-    torch.save(model.state_dict(), os.path.join(args.model_dir, "model.pth"))
-
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--train", type=str, default=os.environ.get("SM_CHANNEL_TRAIN"))
-    parser.add_argument("--model_dir", type=str, default=os.environ.get("SM_MODEL_DIR"))
-    args = parser.parse_args()
-    do_training(args)
+    do_training()

--- a/tests/pytorch/test_training_with_no_grad_updates.py
+++ b/tests/pytorch/test_training_with_no_grad_updates.py
@@ -53,7 +53,7 @@ def init_weights(method):
     return _init_weights
 
 
-def do_training(args):
+def do_training():
     # Generate a matrix of fake random embeddings.
     N = 1000
     EMBEDDING_SIZE = 768

--- a/tests/zero_code_change/test_training_with_no_grad_updates.py
+++ b/tests/zero_code_change/test_training_with_no_grad_updates.py
@@ -104,7 +104,7 @@ def do_training():
         optimizer.step()
 
 
-if __name__ == "__main__":
+def test_training_with_no_grad_updates():
     temp_dir = TemporaryDirectory().name
     path = build_json(temp_dir, include_collections=["losses"], save_interval="1")
     os.environ["SMDEBUG_CONFIG_FILE_PATH"] = str(path)

--- a/tests/zero_code_change/test_training_with_no_grad_updates.py
+++ b/tests/zero_code_change/test_training_with_no_grad_updates.py
@@ -4,8 +4,8 @@ from tempfile import TemporaryDirectory
 
 # Third Party
 import torch
+from tests.zero_code_change.utils import build_json
 from torch.utils.data import DataLoader, IterableDataset
-from utils import build_json
 
 # First Party
 from smdebug.trials import create_trial

--- a/tests/zero_code_change/test_training_with_no_grad_updates.py
+++ b/tests/zero_code_change/test_training_with_no_grad_updates.py
@@ -76,8 +76,6 @@ def do_training():
 
     # Setup model.
     model = TestModel(embedding_size=EMBEDDING_SIZE).to(get_device())
-    for parameter in model.parameters():
-        parameter.requires_grad = False
 
     # Setup criterion.
     criterion = torch.nn.CosineEmbeddingLoss()

--- a/tests/zero_code_change/test_training_with_no_grad_updates.py
+++ b/tests/zero_code_change/test_training_with_no_grad_updates.py
@@ -76,6 +76,8 @@ def do_training():
 
     # Setup model.
     model = TestModel(embedding_size=EMBEDDING_SIZE).to(get_device())
+    for parameter in model.parameters():
+        parameter.requires_grad = False
 
     # Setup criterion.
     criterion = torch.nn.CosineEmbeddingLoss()


### PR DESCRIPTION
### Description of changes:
- The hook crashes with the error `RuntimeError: cannot register a hook on a tensor that doesn't require gradient` when training with pretrained embeddings, see Issue #184 for more details
- This PR adds a check to see if the tensor requires gradient before registering the hook

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available
#184 **Crash occurs when trying to register a hook on a tensor that doesn't require gradients**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
