### PR TITLE
Handle the exception thrown when we try to log uninitialized params

### DIFF
--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -105,7 +105,9 @@ class Hook(CallbackHook):
                     tensor_value=param.grad(param.list_ctx()[0]),
                 )
         except RuntimeError as e:
-            self.logger.warning(f"Could not log parameter {param} due to the mxnet exception: {e}")
+            self.logger.warning(
+                f"Could not log parameter {param.name} due to the mxnet exception: {e}"
+            )
 
     def _export_model(self):
         if self.model is not None:


### PR DESCRIPTION
### Description of changes:
Handle the exception thrown when we try to log uninitialized params

While launching this training job - https://github.com/anirudhacharya/MLProjects/blob/master/train_ssd.py on sagemaker where all the parameters are not initialized, we would encounter the following error log even when the training job succeeded - 
```bash
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
File "/usr/local/lib/python3.6/site-packages/smdebug/mxnet/hook.py", line 85, in _cleanup
self._log_params(self.last_block)
File "/usr/local/lib/python3.6/site-packages/smdebug/mxnet/hook.py", line 93, in _log_params
self._log_param(param)
File "/usr/local/lib/python3.6/site-packages/smdebug/mxnet/hook.py", line 96, in _log_param
self._save_for_tensor(tensor_name=param.name, tensor_value=param.data(param.list_ctx()[0]))

File "/usr/local/lib/python3.6/site-packages/mxnet/gluon/parameter.py", line 610, in list_ctx
raise RuntimeError("Parameter '%s' has not been initialized"%self.name)
RuntimeError: Parameter 'ssd0_resnetv10_dense0_weight' has not been initialized
2020-03-27 14:49:40,220 sagemaker-containers INFO Reporting training SUCCESS
```
We need proper exception handling in the `log_param` function to prevent this from happening.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
