### PR TITLE
Name clash when operator is called multiple times during forward pass

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -882,14 +882,16 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        idx = self.written_tensor_name_for_step.get(name + CallbackHook.INPUT_TENSOR_SUFFIX, 0)
-        self.written_tensor_name_for_step[name] = self._write(
+        tensor_name = name + CallbackHook.INPUT_TENSOR_SUFFIX
+        idx = self.written_tensor_name_for_step.get(tensor_name, 0)
+        self.written_tensor_name_for_step[tensor_name] = self._write(
             name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=idx
         )
 
     def _write_outputs(self, name, outputs):
-        idx = self.written_tensor_name_for_step.get(name + CallbackHook.OUTPUT_TENSOR_SUFFIX, 0)
-        self.written_tensor_name_for_step[name] = self._write(
+        tensor_name = name + CallbackHook.OUTPUT_TENSOR_SUFFIX
+        idx = self.written_tensor_name_for_step.get(tensor_name, 0)
+        self.written_tensor_name_for_step[tensor_name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )
 

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -177,6 +177,13 @@ class BaseHook:
         self.collection_manager = collection_manager
         self.init_step = init_step
 
+        # The written_tensor_name_for_step dictionary stores
+        # the names of each tensor saved for every step.
+        # This is to detect name clashes.
+        # If a name clash is detected, it is avoided by appending
+        # an index to the tensor name.
+        self.written_tensor_name_for_step = defaultdict(int)
+
         self.logger = logger
 
         if self.tensorboard_dir is None:
@@ -850,12 +857,6 @@ class CallbackHook(BaseHook):
         )
         self.exported_collections = False
         self.data_type_name = data_type_name
-        # The written_tensor_name_for_step dictionary stores
-        # the names of each tensor saved for every step.
-        # This is to detect name clashes.
-        # If a name clash is detected, it is avoided by appending
-        # an index to the tensor name.
-        self.written_tensor_name_for_step = defaultdict(int)
 
     def _cleanup(self):
         if not self.exported_collections:

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -884,7 +884,7 @@ class CallbackHook(BaseHook):
     def _write_inputs(self, name, inputs):
         idx = self.written_tensor_name_for_step.get(name, 0)
         self.written_tensor_name_for_step[name] = self._write(
-            name, inputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
+            name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=idx
         )
 
     def _write_outputs(self, name, outputs):

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -4,6 +4,7 @@ import os
 import re as _re
 import time
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from typing import Dict, List, Optional, Set, Union
 
 # Third Party
@@ -848,6 +849,7 @@ class CallbackHook(BaseHook):
         )
         self.exported_collections = False
         self.data_type_name = data_type_name
+        self.written_tensors = defaultdict(int)
 
     def _cleanup(self):
         if not self.exported_collections:
@@ -874,10 +876,16 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        self._write(name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=0)
+        idx = self.written_tensors.get(name, default=0)
+        self.written_tensors[name] = self._write(
+            name, inputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
+        )
 
     def _write_outputs(self, name, outputs):
-        self._write(name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=0)
+        idx = self.written_tensors.get(name, default=0)
+        self.written_tensors[name] = self._write(
+            name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
+        )
 
     @abstractmethod
     def _export_model(self):

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -882,7 +882,7 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        idx = self.written_tensor_name_for_step.get(name + CallbackHook.OUTPUT_TENSOR_SUFFIX, 0)
+        idx = self.written_tensor_name_for_step.get(name + CallbackHook.INPUT_TENSOR_SUFFIX, 0)
         self.written_tensor_name_for_step[name] = self._write(
             name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -876,13 +876,13 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        idx = self.written_tensors.get(name, default=0)
+        idx = self.written_tensors.get(name, 0)
         self.written_tensors[name] = self._write(
             name, inputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )
 
     def _write_outputs(self, name, outputs):
-        idx = self.written_tensors.get(name, default=0)
+        idx = self.written_tensors.get(name, 0)
         self.written_tensors[name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -882,13 +882,13 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        idx = self.written_tensor_name_for_step.get(name, 0)
+        idx = self.written_tensor_name_for_step.get(name + CallbackHook.OUTPUT_TENSOR_SUFFIX, 0)
         self.written_tensor_name_for_step[name] = self._write(
             name, inputs, CallbackHook.INPUT_TENSOR_SUFFIX, idx=idx
         )
 
     def _write_outputs(self, name, outputs):
-        idx = self.written_tensor_name_for_step.get(name, 0)
+        idx = self.written_tensor_name_for_step.get(name + CallbackHook.OUTPUT_TENSOR_SUFFIX, 0)
         self.written_tensor_name_for_step[name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -497,6 +497,7 @@ class BaseHook:
 
         self.step += 1
         self.mode_steps[self.mode] += 1
+        self.written_tensors.clear()
 
         # Increment Global step number irrespective of what mode it is
         if self.mode != ModeKeys.GLOBAL:

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -497,7 +497,7 @@ class BaseHook:
 
         self.step += 1
         self.mode_steps[self.mode] += 1
-        self.written_tensors.clear()
+        self.written_tensor_name_for_step.clear()
 
         # Increment Global step number irrespective of what mode it is
         if self.mode != ModeKeys.GLOBAL:
@@ -850,7 +850,12 @@ class CallbackHook(BaseHook):
         )
         self.exported_collections = False
         self.data_type_name = data_type_name
-        self.written_tensors = defaultdict(int)
+        # The written_tensor_name_for_step dictionary stores
+        # the names of each tensor saved for every step.
+        # This is to detect name clashes.
+        # If a name clash is detected, it is avoided by appending
+        # an index to the tensor name.
+        self.written_tensor_name_for_step = defaultdict(int)
 
     def _cleanup(self):
         if not self.exported_collections:
@@ -877,14 +882,14 @@ class CallbackHook(BaseHook):
         return idx
 
     def _write_inputs(self, name, inputs):
-        idx = self.written_tensors.get(name, 0)
-        self.written_tensors[name] = self._write(
+        idx = self.written_tensor_name_for_step.get(name, 0)
+        self.written_tensor_name_for_step[name] = self._write(
             name, inputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )
 
     def _write_outputs(self, name, outputs):
-        idx = self.written_tensors.get(name, 0)
-        self.written_tensors[name] = self._write(
+        idx = self.written_tensor_name_for_step.get(name, 0)
+        self.written_tensor_name_for_step[name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )
 

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -37,7 +37,7 @@ def test_data_parallel():
     trial = create_trial(out_dir)
     assert trial.steps() == [0, 1, 5]
     if device == "cpu":
-        assert len(trial.tensor_names()) == 37
+        assert len(trial.tensor_names()) == 38
     else:
         assert len(trial.tensor_names()) > 37
 

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -78,8 +78,8 @@ def test_register_loss_functional(out_dir):
     loss_tensor = trial.tensor("nll_loss_output_0")
 
     # Capture ['nll_loss_output_0']
-    assert len(trial.tensor_names()) == 1
-    assert len(loss_coll.tensor_names) == 1
+    assert len(trial.tensor_names()) == 2
+    assert len(loss_coll.tensor_names) == 2
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps

--- a/tests/pytorch/test_no_name_clash.py
+++ b/tests/pytorch/test_no_name_clash.py
@@ -47,7 +47,6 @@ def test_no_name_clash():
     )
     model = Net()
     hook.register_module(model)
-    device = "cuda" if torch.cuda.is_available() else "cpu"
     device = "cpu"
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device(device), optimizer, num_steps=10)
@@ -55,5 +54,5 @@ def test_no_name_clash():
     trial = create_trial(out_dir)
     assert trial.steps() == [0, 1, 5]
 
-    assert len(trial.tensor_names()) == 37
+    assert len(trial.tensor_names()) == 38
     shutil.rmtree(out_dir, ignore_errors=True)

--- a/tests/pytorch/test_no_name_clash.py
+++ b/tests/pytorch/test_no_name_clash.py
@@ -54,5 +54,5 @@ def test_no_name_clash():
     trial = create_trial(out_dir)
     assert trial.steps() == [0, 1, 5]
 
-    assert len(trial.tensor_names()) == 38
+    assert len(trial.tensor_names(regex="relu.*")) == 6
     shutil.rmtree(out_dir, ignore_errors=True)

--- a/tests/pytorch/test_no_name_clash.py
+++ b/tests/pytorch/test_no_name_clash.py
@@ -1,0 +1,59 @@
+# Standard Library
+import shutil
+from tempfile import TemporaryDirectory
+
+# Third Party
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from tests.pytorch.utils import train
+
+# First Party
+import smdebug.pytorch as smd
+from smdebug.trials import create_trial
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.add_module("conv1", nn.Conv2d(1, 20, 5, 1))
+        self.add_module("max_pool", nn.MaxPool2d(2, stride=2))
+        self.add_module("conv2", nn.Conv2d(20, 50, 5, 1))
+        self.relu = nn.ReLU()
+        self.add_module("max_pool2", nn.MaxPool2d(2, stride=2))
+        self.add_module("fc1", nn.Linear(4 * 4 * 50, 500))
+        self.add_module("fc2", nn.Linear(500, 10))
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        x = self.max_pool(x)
+        x = self.relu(self.conv2(x))
+        x = self.max_pool2(x)
+        x = x.view(-1, 4 * 4 * 50)
+        x = self.relu(self.fc1(x))
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+def test_no_name_clash():
+    out_dir = TemporaryDirectory().name
+
+    hook = smd.Hook(
+        out_dir=out_dir,
+        save_config=smd.SaveConfig(save_steps=[0, 1, 5]),
+        save_all=True,
+        include_workers="one",
+    )
+    model = Net()
+    hook.register_module(model)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cpu"
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+    train(model, hook, torch.device(device), optimizer, num_steps=10)
+
+    trial = create_trial(out_dir)
+    assert trial.steps() == [0, 1, 5]
+
+    assert len(trial.tensor_names()) == 37
+    shutil.rmtree(out_dir, ignore_errors=True)


### PR DESCRIPTION
### Description of changes:
- Tensors with the same name saved for a step are being overwritten.
- This PR adds a dictionary that records the name of each tensor saved every step and adds logic that increments an index suffix that is appended to the tensor name

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available
#187 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
