### PR TITLE
Bug Fix to prevent repeated writes to metadata.json

### DIFF
--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -31,8 +31,8 @@ phases:
 
   build:
     commands:
-      - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh && cd ..
-      - cd $CODEBUILD_SRC_DIR_RULES && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && cd ..
+      - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. ./config/tests.sh && cd ..
+      - cd $CODEBUILD_SRC_DIR_RULES && chmod +x config/tests.sh && PYTHONPATH=. ./config/tests.sh  && cd ..
 
   post_build:
     commands:

--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -31,8 +31,8 @@ phases:
 
   build:
     commands:
-      - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. ./config/tests.sh && cd ..
-      - cd $CODEBUILD_SRC_DIR_RULES && chmod +x config/tests.sh && PYTHONPATH=. ./config/tests.sh  && cd ..
+      - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh && cd ..
+      - cd $CODEBUILD_SRC_DIR_RULES && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && cd ..
 
   post_build:
     commands:

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -1,7 +1,6 @@
 # Standard Library
 import json
 import os
-import time
 
 # First Party
 from smdebug.core.config_constants import (
@@ -119,4 +118,4 @@ class StateStore:
         self._saved_states.append(ts_state)
         with open(self._states_file, "w") as out_file:
             json.dump(self._saved_states, out_file)
-        self._checkpoint_update_timestamp = time.time()
+        self._checkpoint_update_timestamp = os.path.getmtime(self._states_file)

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -86,6 +86,12 @@ class StateStore:
             if not checkpoint_files:
                 return False
             timestamps = [os.path.getmtime(file) for file in checkpoint_files]
+            logger.debug(
+                f"Timestamps of different checkpoint files {[i for i in zip(checkpoint_files, timestamps)]}"
+            )
+            logger.debug(
+                f"Timestamp of the last checkpoint update: {self._checkpoint_update_timestamp}"
+            )
             if max(timestamps) > self._checkpoint_update_timestamp:
                 return True
         return False

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -28,6 +28,7 @@ class StateStore:
         self._states_file = None
         self._checkpoint_dir = None
         self._retrieve_path_to_checkpoint()
+        self._max_timestamp_seen = 0
         if self._checkpoint_dir is not None:
             self._states_file = os.path.join(self._checkpoint_dir, METADATA_FILENAME)
             self._read_states_file()
@@ -94,9 +95,10 @@ class StateStore:
             logger.debug(
                 f"Timestamp of the last checkpoint update: {self._checkpoint_update_timestamp}"
             )
-            if max(timestamps) > self._checkpoint_update_timestamp:
+            self._max_timestamp_seen = max(timestamps)
+            if  max_timestamp_seen > self._checkpoint_update_timestamp:
                 logger.debug(
-                    f"The most recent timestamp of the checkpoint files: {max(timestamps)}"
+                    f"The most recent timestamp of the checkpoint files: {self._max_timestamp_seen}"
                 )
                 return True
         return False
@@ -118,4 +120,4 @@ class StateStore:
         self._saved_states.append(ts_state)
         with open(self._states_file, "w") as out_file:
             json.dump(self._saved_states, out_file)
-        self._checkpoint_update_timestamp = os.path.getmtime(self._states_file)
+        self._checkpoint_update_timestamp = self._max_timestamp_seen

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -78,19 +78,14 @@ class StateStore:
         stored got updated.
         """
         if self._checkpoint_dir is not None:
-            timestamps = [
-                os.path.getmtime(child)
-                for child, _, _ in os.walk(self._checkpoint_dir)
-                if child != self._checkpoint_dir
-            ]
-            _, _, files = next(os.walk(self._checkpoint_dir))
-            timestamps += [
-                os.path.getmtime(os.path.join(self._checkpoint_dir, file))
-                for file in files
-                if file != METADATA_FILENAME
-            ]
-            if not timestamps:
+            checkpoint_files = []
+            for child, _, files in os.walk(self._checkpoint_dir):
+                for file in files:
+                    if file != METADATA_FILENAME:
+                        checkpoint_files.append(os.path.join(child, file))
+            if not checkpoint_files:
                 return False
+            timestamps = [os.path.getmtime(file) for file in checkpoint_files]
             if max(timestamps) > self._checkpoint_update_timestamp:
                 return True
         return False

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -96,7 +96,7 @@ class StateStore:
                 f"Timestamp of the last checkpoint update: {self._checkpoint_update_timestamp}"
             )
             self._max_timestamp_seen = max(timestamps)
-            if  max_timestamp_seen > self._checkpoint_update_timestamp:
+            if  self._max_timestamp_seen > self._checkpoint_update_timestamp:
                 logger.debug(
                     f"The most recent timestamp of the checkpoint files: {self._max_timestamp_seen}"
                 )

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -84,6 +84,9 @@ class StateStore:
                     if file != METADATA_FILENAME:
                         checkpoint_files.append(os.path.join(child, file))
             if not checkpoint_files:
+                logger.debug(
+                    "Checkpoints not updated. There are no checkpoint files created yet, to be updated"
+                )
                 return False
             timestamps = [os.path.getmtime(file) for file in checkpoint_files]
             logger.debug(
@@ -93,6 +96,9 @@ class StateStore:
                 f"Timestamp of the last checkpoint update: {self._checkpoint_update_timestamp}"
             )
             if max(timestamps) > self._checkpoint_update_timestamp:
+                logger.debug(
+                    f"The most recent timestamp of the checkpoint files: {max(timestamps)}"
+                )
                 return True
         return False
 

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -1,0 +1,63 @@
+# Standard Library
+import os
+import shutil
+import time
+
+# First Party
+from smdebug.core.state_store import StateStore
+
+
+def setup_test1():
+    try:
+        shutil.rmtree("checkpoints_test_dir/")
+    except:
+        pass
+    os.mkdir("checkpoints_test_dir/")
+    os.mkdir("checkpoints_test_dir/subdir1")
+    os.mkdir("checkpoints_test_dir/subdir2")
+    dir_path = os.path.abspath("checkpoints_test_dir")
+    with open(dir_path + "/metadata.json", "w") as f:
+        pass
+    with open(dir_path + "/config_test.json", "w") as f:
+        pass
+    with open(dir_path + "/subdir1/checkpoint_test1.txt", "w") as f:
+        pass
+    with open(dir_path + "/subdir2/checkpoint_test2.txt", "w") as f:
+        pass
+    return dir_path
+
+
+def setup_test2():
+    try:
+        shutil.rmtree("checkpoints_test_dir/")
+    except:
+        pass
+    os.mkdir("checkpoints_test_dir/")
+    dir_path = os.path.abspath("checkpoints_test_dir")
+    with open(dir_path + "/metadata.json", "w") as f:
+        pass
+    return dir_path
+
+
+def test_is_checkpoint_updated():
+    s1 = StateStore()
+    s1._checkpoint_update_timestamp = time.time()
+    s1._checkpoint_dir = setup_test1()
+    # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
+    assert s1.is_checkpoint_updated()
+
+    s1._checkpoint_update_timestamp = time.time()
+    # the checkpoint update time is lesser than _checkpoint_update_timestamp. is_checkpoint_updated should return false.
+    assert not s1.is_checkpoint_updated()
+    shutil.rmtree(s1._checkpoint_dir)
+
+    s2 = StateStore()
+    s2._checkpoint_update_timestamp = time.time()
+    s2._checkpoint_dir = setup_test2()
+    # setup_test2 has only metadata.json in the checkpoints_dir. So no checkpoints file was created or updated. It should return false.
+    assert not s2.is_checkpoint_updated()
+
+    s2._checkpoint_update_timestamp = time.time()
+    # setup_test2 has only metadata.json in the checkpoints_dir. So no checkpoints file was created or updated. It should return false.
+    assert not s2.is_checkpoint_updated()
+    shutil.rmtree(s2._checkpoint_dir)

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -42,6 +42,7 @@ def cleanup(checkpoints_dir_path, config_path):
 
 
 def test_is_checkpoint_updated():
+    os.environ["SMDEBUG_LOG_LEVEL"] = "debug"
     s1 = StateStore()
     # There is no checkpoint_dir. is_checkpoint_updated should return False.
     assert s1.is_checkpoint_updated() is False
@@ -57,8 +58,8 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated() is False
 
     os.mkdir(s2._checkpoint_dir + "/subdir1")
-    with open(checkpoints_dir_path + "/subdir1/checkpoint_test1.txt", "w") as f:
-        pass
+    with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "w") as f:
+        f.write("checkpoint-test-string-1")
     # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
 
@@ -68,7 +69,7 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated() is False
 
     with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "a") as f:
-        f.write("test-string")
+        f.write("checkpoint-test-string-2")
     # A checkpoint file has been updated. The checkpoint update time is greater than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
@@ -76,7 +77,7 @@ def test_is_checkpoint_updated():
     s2.update_state("test-state3")
     os.mkdir(s2._checkpoint_dir + "/subdir2")
     with open(s2._checkpoint_dir + "/subdir2/checkpoint_test2.txt", "w") as f:
-        pass
+        f.write("checkpoint-test-string-3")
     # A new checkpoint file has been created. The checkpoint update time is greater than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -55,22 +55,25 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated() is False
 
     s2.update_state("test-state1")
-    time.sleep(1)
     # checkpoints_dir still has only metadata.json. It should return false.
     assert s2.is_checkpoint_updated() is False
 
+    time.sleep(0.01)
     os.mkdir(s2._checkpoint_dir + "/subdir1")
     with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "w") as f:
         f.write("checkpoint-test-string-1")
     # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
+    print(f"\nlast update timestamp: {s2._checkpoint_update_timestamp}")
+    chkpnt_fname = s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt"
+    print(f"checkpoint file timestamp: {os.path.getmtime(chkpnt_fname)}")
     assert s2.is_checkpoint_updated()
 
     s2.update_state("test-state2")
-    time.sleep(1)
     # the state_file has been updated. The lastest checkpoint update time is lesser than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return false.
     assert s2.is_checkpoint_updated() is False
 
+    time.sleep(0.01)
     with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "a") as f:
         f.write("checkpoint-test-string-2")
     # A checkpoint file has been updated. The checkpoint update time is greater than _checkpoint_update_timestamp.
@@ -78,7 +81,7 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated()
 
     s2.update_state("test-state3")
-    time.sleep(1)
+    time.sleep(0.01)
     os.mkdir(s2._checkpoint_dir + "/subdir2")
     with open(s2._checkpoint_dir + "/subdir2/checkpoint_test2.txt", "w") as f:
         f.write("checkpoint-test-string-3")

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -1,63 +1,83 @@
 # Standard Library
+import json
 import os
 import shutil
-import time
 
 # First Party
 from smdebug.core.state_store import StateStore
 
 
-def setup_test1():
+def setup_test():
     try:
         shutil.rmtree("checkpoints_test_dir/")
     except:
         pass
-    os.mkdir("checkpoints_test_dir/")
-    os.mkdir("checkpoints_test_dir/subdir1")
-    os.mkdir("checkpoints_test_dir/subdir2")
-    dir_path = os.path.abspath("checkpoints_test_dir")
-    with open(dir_path + "/metadata.json", "w") as f:
-        pass
-    with open(dir_path + "/config_test.json", "w") as f:
-        pass
-    with open(dir_path + "/subdir1/checkpoint_test1.txt", "w") as f:
-        pass
-    with open(dir_path + "/subdir2/checkpoint_test2.txt", "w") as f:
-        pass
-    return dir_path
-
-
-def setup_test2():
-    try:
-        shutil.rmtree("checkpoints_test_dir/")
-    except:
-        pass
+    # create the checkpoints directory
     os.mkdir("checkpoints_test_dir/")
     dir_path = os.path.abspath("checkpoints_test_dir")
+
+    # create the config file and set the corresponding environment variable.
+    mock_config = {"LocalPath": dir_path}
+    with open("mock_config.json", "w") as f:
+        json.dump(mock_config, f)
+    os.environ["CHECKPOINT_CONFIG_FILE_PATH"] = os.path.abspath("mock_config.json")
+
+    # create the metadata file inside the checkpoints directory.
+    mock_metadata = [
+        {
+            "training-run": "",
+            "latest-global-step-saved": "",
+            "latest-global-step-seen": "",
+            "latest-mode-step": "",
+        }
+    ]
     with open(dir_path + "/metadata.json", "w") as f:
-        pass
-    return dir_path
+        json.dump(mock_metadata, f)
+    return dir_path, os.path.abspath("mock_config.json")
+
+
+def cleanup(checkpoints_dir_path, config_path):
+    shutil.rmtree(checkpoints_dir_path)
+    os.remove(config_path)
 
 
 def test_is_checkpoint_updated():
     s1 = StateStore()
-    s1._checkpoint_update_timestamp = time.time()
-    s1._checkpoint_dir = setup_test1()
-    # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
-    assert s1.is_checkpoint_updated()
+    # There is no checkpoint_dir. is_checkpoint_updated should return False.
+    assert s1.is_checkpoint_updated() is False
 
-    s1._checkpoint_update_timestamp = time.time()
-    # the checkpoint update time is lesser than _checkpoint_update_timestamp. is_checkpoint_updated should return false.
-    assert not s1.is_checkpoint_updated()
-    shutil.rmtree(s1._checkpoint_dir)
-
+    # call setup_test to create checkpoints_dir and metadata file.
+    checkpoints_dir_path, config_path = setup_test()
     s2 = StateStore()
-    s2._checkpoint_update_timestamp = time.time()
-    s2._checkpoint_dir = setup_test2()
-    # setup_test2 has only metadata.json in the checkpoints_dir. So no checkpoints file was created or updated. It should return false.
-    assert not s2.is_checkpoint_updated()
+    # checkpoints_dir only has metadata.json. So no checkpoints file was created or updated. It should return false.
+    assert s2.is_checkpoint_updated() is False
 
-    s2._checkpoint_update_timestamp = time.time()
-    # setup_test2 has only metadata.json in the checkpoints_dir. So no checkpoints file was created or updated. It should return false.
-    assert not s2.is_checkpoint_updated()
-    shutil.rmtree(s2._checkpoint_dir)
+    s2.update_state("test-state1")
+    # checkpoints_dir still has only metadata.json. It should return false.
+    assert s2.is_checkpoint_updated() is False
+
+    os.mkdir(checkpoints_dir_path + "/subdir1")
+    with open(checkpoints_dir_path + "/subdir1/checkpoint_test1.txt", "w") as f:
+        pass
+    # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
+    assert s2.is_checkpoint_updated()
+
+    s2.update_state("test-state")
+    # the state_file has been updated. The lastest checkpoint update time is lesser than _checkpoint_update_timestamp.
+    # is_checkpoint_updated should return false.
+    assert s2.is_checkpoint_updated() is False
+
+    with open(checkpoints_dir_path + "/subdir1/checkpoint_test1.txt", "a") as f:
+        f.write("test-string")
+    # A checkpoint file has been updated. The checkpoint update time is greater than _checkpoint_update_timestamp.
+    # is_checkpoint_updated should return true.
+    assert s2.is_checkpoint_updated()
+
+    s2.update_state("test-state1")
+    os.mkdir(checkpoints_dir_path + "/subdir2")
+    with open(checkpoints_dir_path + "/subdir2/checkpoint_test2.txt", "w") as f:
+        pass
+    # A new checkpoint file has been created. The checkpoint update time is greater than _checkpoint_update_timestamp.
+    # is_checkpoint_updated should return true.
+    assert s2.is_checkpoint_updated()
+    cleanup(checkpoints_dir_path, config_path)

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -58,7 +58,6 @@ def test_is_checkpoint_updated():
     # checkpoints_dir still has only metadata.json. It should return false.
     assert s2.is_checkpoint_updated() is False
 
-    time.sleep(0.01)
     os.mkdir(s2._checkpoint_dir + "/subdir1")
     with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "w") as f:
         f.write("checkpoint-test-string-1")
@@ -73,7 +72,6 @@ def test_is_checkpoint_updated():
     # is_checkpoint_updated should return false.
     assert s2.is_checkpoint_updated() is False
 
-    time.sleep(0.01)
     with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "a") as f:
         f.write("checkpoint-test-string-2")
     # A checkpoint file has been updated. The checkpoint update time is greater than _checkpoint_update_timestamp.
@@ -81,7 +79,6 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated()
 
     s2.update_state("test-state3")
-    time.sleep(0.01)
     os.mkdir(s2._checkpoint_dir + "/subdir2")
     with open(s2._checkpoint_dir + "/subdir2/checkpoint_test2.txt", "w") as f:
         f.write("checkpoint-test-string-3")

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -56,28 +56,28 @@ def test_is_checkpoint_updated():
     # checkpoints_dir still has only metadata.json. It should return false.
     assert s2.is_checkpoint_updated() is False
 
-    os.mkdir(checkpoints_dir_path + "/subdir1")
+    os.mkdir(s2._checkpoint_dir + "/subdir1")
     with open(checkpoints_dir_path + "/subdir1/checkpoint_test1.txt", "w") as f:
         pass
     # the checkpoint update time is greater than _checkpoint_update_timestamp. is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
 
-    s2.update_state("test-state")
+    s2.update_state("test-state2")
     # the state_file has been updated. The lastest checkpoint update time is lesser than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return false.
     assert s2.is_checkpoint_updated() is False
 
-    with open(checkpoints_dir_path + "/subdir1/checkpoint_test1.txt", "a") as f:
+    with open(s2._checkpoint_dir + "/subdir1/checkpoint_test1.txt", "a") as f:
         f.write("test-string")
     # A checkpoint file has been updated. The checkpoint update time is greater than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
 
-    s2.update_state("test-state1")
-    os.mkdir(checkpoints_dir_path + "/subdir2")
-    with open(checkpoints_dir_path + "/subdir2/checkpoint_test2.txt", "w") as f:
+    s2.update_state("test-state3")
+    os.mkdir(s2._checkpoint_dir + "/subdir2")
+    with open(s2._checkpoint_dir + "/subdir2/checkpoint_test2.txt", "w") as f:
         pass
     # A new checkpoint file has been created. The checkpoint update time is greater than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
-    cleanup(checkpoints_dir_path, config_path)
+    cleanup(s2._checkpoint_dir, config_path)

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+import time
 
 # First Party
 from smdebug.core.state_store import StateStore
@@ -54,6 +55,7 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated() is False
 
     s2.update_state("test-state1")
+    time.sleep(1)
     # checkpoints_dir still has only metadata.json. It should return false.
     assert s2.is_checkpoint_updated() is False
 
@@ -64,6 +66,7 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated()
 
     s2.update_state("test-state2")
+    time.sleep(1)
     # the state_file has been updated. The lastest checkpoint update time is lesser than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return false.
     assert s2.is_checkpoint_updated() is False
@@ -75,10 +78,12 @@ def test_is_checkpoint_updated():
     assert s2.is_checkpoint_updated()
 
     s2.update_state("test-state3")
+    time.sleep(1)
     os.mkdir(s2._checkpoint_dir + "/subdir2")
     with open(s2._checkpoint_dir + "/subdir2/checkpoint_test2.txt", "w") as f:
         f.write("checkpoint-test-string-3")
     # A new checkpoint file has been created. The checkpoint update time is greater than _checkpoint_update_timestamp.
     # is_checkpoint_updated should return true.
     assert s2.is_checkpoint_updated()
+    del os.environ["SMDEBUG_LOG_LEVEL"]
     cleanup(s2._checkpoint_dir, config_path)


### PR DESCRIPTION
### Description of changes:
During a Sagemaker training job, there was an issue of the `metadata.json` file in the `checkpoints_dir` being re-written every second.

This probably happened because we use `json.dumps` [here](https://github.com/awslabs/sagemaker-debugger/blob/master/smdebug/core/state_store.py#L104) to write to the `states_file` every time the `last_modified_time` of the `checkpoint_dir` is greater than `last_Saved time`( [checked here](https://github.com/awslabs/sagemaker-debugger/blob/master/smdebug/core/state_store.py#L75)). 

`json.dumps` may not guarantee that file was actually written to disk. The file could be in cache and flushed to disk asynchronously a second later. In such a case the `last_modified_time` of the file will always be more than `last_Saved time`. 

To fix it I have filtered out the `states_file` while determining if the `checkpoint_dir` has been updated( [here](https://github.com/awslabs/sagemaker-debugger/blob/master/smdebug/core/state_store.py#L82)).

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
