### PR TITLE
Split gradtape and keras tests

### DIFF
--- a/config/tests.sh
+++ b/config/tests.sh
@@ -25,6 +25,7 @@ run_for_framework() {
       elif [ "$1" = "tensorflow" ] ; then
         python tests/zero_code_change/tensorflow_integration_tests.py
       elif [ "$1" = "tensorflow2" ] ; then
+        python tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
         python tests/zero_code_change/tensorflow2_integration_tests.py
       fi
 

--- a/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
@@ -111,7 +111,7 @@ def test_keras_v2_multi_collections(script_mode: bool = False):
                 "S3OutputPath": "s3://sagemaker-test",
                 "LocalPath": "/opt/ml/output/tensors",
                 "HookParameters" : {
-                    "save_interval": "2",
+                    "save_interval": "100",
                     "include_workers": "all"
                 },
                 "CollectionConfigurations": [

--- a/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
@@ -1,0 +1,161 @@
+"""
+WARNING: This test is useful for DLC testing.
+
+Test with Keras GradientTape.
+
+We check that certain tensors are saved.
+Here in the test suite we delete the hook after every script.
+"""
+# Standard Library
+import argparse
+
+# Third Party
+import tensorflow.compat.v2 as tf
+
+# First Party
+import smdebug.tensorflow as smd
+from smdebug.core.utils import SagemakerSimulator
+
+
+def get_keras_data():
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+    return (x_train, y_train), (x_test, y_test)
+
+
+def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_contents="{}"):
+    """ Test the default ZCC behavior of saving losses and metrics in eager and non-eager modes."""
+    smd.del_hook()
+    tf.keras.backend.clear_session()
+
+    with SagemakerSimulator(json_file_contents=json_file_contents) as sim:
+        model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Flatten(input_shape=(28, 28, 1)),  # WA for TF issue #36279
+                tf.keras.layers.Dense(128, activation="relu"),
+                tf.keras.layers.Dropout(0.2),
+                tf.keras.layers.Dense(10, activation="softmax"),
+            ]
+        )
+        (x_train, y_train), _ = get_keras_data()
+        dataset = tf.data.Dataset.from_tensor_slices(
+            (tf.cast(x_train[..., tf.newaxis] / 255, tf.float32), tf.cast(y_train, tf.int64))
+        )
+        dataset = dataset.shuffle(1000).batch(64)
+
+        opt = tf.keras.optimizers.RMSprop()
+        cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+        train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
+        n_epochs = 5
+        if script_mode:
+            if json_file_contents == "{}":
+                hook = smd.KerasHook(out_dir=sim.out_dir, export_tensorboard=True)
+            else:
+                hook = smd.KerasHook.create_from_json_file()
+
+            for epoch in range(n_epochs):
+                for data, labels in dataset:
+                    dataset_labels = labels
+                    labels = tf.one_hot(labels, depth=10)
+                    with hook.wrap_tape(tf.GradientTape()) as tape:
+                        logits = model(data, training=True)  # (32,10)
+                        loss_value = cce(labels, logits)
+                    grads = tape.gradient(loss_value, model.variables)
+                    opt.apply_gradients(zip(grads, model.variables))
+                    acc = train_acc_metric(dataset_labels, logits)
+                    hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
+                train_acc_metric.reset_states()
+            hook = smd.get_hook()
+            assert hook
+            hook.close()
+            # Check that hook created and tensors saved
+            trial = smd.create_trial(path=sim.out_dir)
+            assert len(trial.steps()) > 0, "Nothing saved at any step."
+            assert len(trial.tensor_names()) > 0, "Tensors were not saved."
+            assert len(trial.tensor_names(collection="losses")) > 0
+        else:
+            # ZCC doesn't support yet (as of smdebug v0.7.2)
+            for epoch in range(n_epochs):
+                for data, labels in dataset:
+                    dataset_labels = labels
+                    labels = tf.one_hot(labels, depth=10)
+                    with tf.GradientTape(persistent=True) as tape:
+                        logits = model(data, training=True)  # (32,10)
+                        loss_value = cce(labels, logits)
+                    grads = tape.gradient(loss_value, model.variables)
+                    opt.apply_gradients(zip(grads, model.variables))
+                    acc = train_acc_metric(dataset_labels, logits)
+                train_acc_metric.reset_states()
+            hook = smd.get_hook()
+            assert not hook
+
+
+def test_keras_v2_default(script_mode: bool = False):
+    # Test default ZCC behavior
+    helper_test_keras_v2_gradienttape(script_mode=script_mode)
+
+
+def test_keras_v2_multi_collections(script_mode: bool = False):
+    # Test multiple collections included in hook json
+    json_file_contents = """
+            {
+                "S3OutputPath": "s3://sagemaker-test",
+                "LocalPath": "/opt/ml/output/tensors",
+                "HookParameters" : {
+                    "save_interval": "2",
+                    "include_workers": "all"
+                },
+                "CollectionConfigurations": [
+                    {
+                        "CollectionName": "gradients"
+                    },
+                    {
+                        "CollectionName": "weights"
+                    },
+                    {
+                        "CollectionName": "losses"
+                    },
+                    {
+                        "CollectionName": "biases"
+                    },
+                    {
+                        "CollectionName": "optimizer_variables"
+                    }
+                ]
+            }
+            """
+    helper_test_keras_v2_gradienttape(
+        script_mode=script_mode, json_file_contents=json_file_contents
+    )
+
+
+def test_keras_v2_save_all(script_mode: bool = False):
+    # Test save all through hook config
+    json_file_contents = """
+            {
+                "S3OutputPath": "s3://sagemaker-test",
+                "LocalPath": "/opt/ml/output/tensors",
+                "HookParameters" : {
+                    "save_steps": "0,1,2,3",
+                    "save_all": true
+                }
+            }
+            """
+    helper_test_keras_v2_gradienttape(
+        script_mode=script_mode, json_file_contents=json_file_contents
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--script-mode", help="Manually create hooks instead of relying on ZCC", action="store_true"
+    )
+    args = parser.parse_args()
+    script_mode = args.script_mode
+
+    # Gradient Tape eager mode
+    test_keras_v2_default(script_mode)
+    test_keras_v2_multi_collections(script_mode)
+    test_keras_v2_save_all(script_mode)

--- a/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
@@ -47,7 +47,7 @@ def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_conte
         opt = tf.keras.optimizers.RMSprop()
         cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
         train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-        n_epochs = 5
+        n_epochs = 2
         if script_mode:
             if json_file_contents == "{}":
                 hook = smd.KerasHook(out_dir=sim.out_dir, export_tensorboard=True)

--- a/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
@@ -55,6 +55,7 @@ def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_conte
                 hook = smd.KerasHook.create_from_json_file()
 
             for epoch in range(n_epochs):
+                print("Epoch %d/%d" % (epoch + 1, n_epochs))
                 for data, labels in dataset:
                     dataset_labels = labels
                     labels = tf.one_hot(labels, depth=10)
@@ -65,6 +66,9 @@ def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_conte
                     opt.apply_gradients(zip(grads, model.variables))
                     acc = train_acc_metric(dataset_labels, logits)
                     hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
+                log = "Epoch %d " % (epoch + 1)
+                log += "Accuracy %.4f" % train_acc_metric.result()
+                print(log)
                 train_acc_metric.reset_states()
             hook = smd.get_hook()
             assert hook
@@ -77,6 +81,7 @@ def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_conte
         else:
             # ZCC doesn't support yet (as of smdebug v0.7.2)
             for epoch in range(n_epochs):
+                print("Epoch %d/%d" % (epoch + 1, n_epochs))
                 for data, labels in dataset:
                     dataset_labels = labels
                     labels = tf.one_hot(labels, depth=10)
@@ -86,6 +91,9 @@ def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_conte
                     grads = tape.gradient(loss_value, model.variables)
                     opt.apply_gradients(zip(grads, model.variables))
                     acc = train_acc_metric(dataset_labels, logits)
+                log = "Epoch %d " % (epoch + 1)
+                log += "Accuracy %.4f" % train_acc_metric.result()
+                print(log)
                 train_acc_metric.reset_states()
             hook = smd.get_hook()
             assert not hook

--- a/tests/zero_code_change/tensorflow2_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_integration_tests.py
@@ -127,77 +127,8 @@ def helper_test_keras_v2_json_config(
         assert len(trial.tensor_names(collection="losses")) > 0
 
 
-def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_contents="{}"):
-    """ Test the default ZCC behavior of saving losses and metrics in eager and non-eager modes."""
-    smd.del_hook()
-    tf.keras.backend.clear_session()
-
-    with SagemakerSimulator(json_file_contents=json_file_contents) as sim:
-        model = tf.keras.models.Sequential(
-            [
-                tf.keras.layers.Flatten(input_shape=(28, 28, 1)),  # WA for TF issue #36279
-                tf.keras.layers.Dense(128, activation="relu"),
-                tf.keras.layers.Dropout(0.2),
-                tf.keras.layers.Dense(10, activation="softmax"),
-            ]
-        )
-        (x_train, y_train), _ = get_keras_data()
-        dataset = tf.data.Dataset.from_tensor_slices(
-            (tf.cast(x_train[..., tf.newaxis] / 255, tf.float32), tf.cast(y_train, tf.int64))
-        )
-        dataset = dataset.shuffle(1000).batch(64)
-
-        opt = tf.keras.optimizers.RMSprop()
-        cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
-        train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-        n_epochs = 5
-        if script_mode:
-            if json_file_contents == "{}":
-                hook = smd.KerasHook(out_dir=sim.out_dir, export_tensorboard=True)
-            else:
-                hook = smd.KerasHook.create_from_json_file()
-
-            for epoch in range(n_epochs):
-                for data, labels in dataset:
-                    dataset_labels = labels
-                    labels = tf.one_hot(labels, depth=10)
-                    with hook.wrap_tape(tf.GradientTape()) as tape:
-                        logits = model(data, training=True)  # (32,10)
-                        loss_value = cce(labels, logits)
-                    grads = tape.gradient(loss_value, model.variables)
-                    opt.apply_gradients(zip(grads, model.variables))
-                    acc = train_acc_metric(dataset_labels, logits)
-                    hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
-                train_acc_metric.reset_states()
-            hook = smd.get_hook()
-            assert hook
-            hook.close()
-            # Check that hook created and tensors saved
-            trial = smd.create_trial(path=sim.out_dir)
-            assert len(trial.steps()) > 0, "Nothing saved at any step."
-            assert len(trial.tensor_names()) > 0, "Tensors were not saved."
-            assert len(trial.tensor_names(collection="losses")) > 0
-        else:
-            # ZCC doesn't support yet (as of smdebug v0.7.2)
-            for epoch in range(n_epochs):
-                for data, labels in dataset:
-                    dataset_labels = labels
-                    labels = tf.one_hot(labels, depth=10)
-                    with tf.GradientTape(persistent=True) as tape:
-                        logits = model(data, training=True)  # (32,10)
-                        loss_value = cce(labels, logits)
-                    grads = tape.gradient(loss_value, model.variables)
-                    opt.apply_gradients(zip(grads, model.variables))
-                    acc = train_acc_metric(dataset_labels, logits)
-                train_acc_metric.reset_states()
-            hook = smd.get_hook()
-            assert not hook
-
-
 def test_keras_v2_default(script_mode: bool = False, eager_mode: bool = True):
     # Test default ZCC behavior
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(script_mode=script_mode)
     helper_test_keras_v2(script_mode=script_mode, eager_mode=eager_mode)
 
 
@@ -230,10 +161,6 @@ def test_keras_v2_multi_collections(script_mode: bool = False, eager_mode: bool 
                 ]
             }
             """
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(
-            script_mode=script_mode, json_file_contents=json_file_contents
-        )
     helper_test_keras_v2_json_config(
         script_mode=script_mode, eager_mode=eager_mode, json_file_contents=json_file_contents
     )
@@ -251,10 +178,6 @@ def test_keras_v2_save_all(script_mode: bool = False, eager_mode: bool = True):
                 }
             }
             """
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(
-            script_mode=script_mode, json_file_contents=json_file_contents
-        )
     helper_test_keras_v2_json_config(
         script_mode=script_mode, eager_mode=eager_mode, json_file_contents=json_file_contents
     )

--- a/tests/zero_code_change/tensorflow2_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_integration_tests.py
@@ -63,14 +63,14 @@ def helper_test_keras_v2(script_mode: bool = False, eager_mode: bool = True):
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
             history = model.fit(
-                x_train, y_train, batch_size=64, epochs=5, validation_split=0.2, callbacks=[hook]
+                x_train, y_train, batch_size=64, epochs=2, validation_split=0.2, callbacks=[hook]
             )
             test_scores = model.evaluate(x_test, y_test, verbose=2, callbacks=[hook])
         else:
             model.compile(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
-            history = model.fit(x_train, y_train, batch_size=64, epochs=5, validation_split=0.2)
+            history = model.fit(x_train, y_train, batch_size=64, epochs=2, validation_split=0.2)
             test_scores = model.evaluate(x_test, y_test, verbose=2)
 
         hook = smd.get_hook()
@@ -104,14 +104,14 @@ def helper_test_keras_v2_json_config(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
             history = model.fit(
-                x_train, y_train, batch_size=64, epochs=5, validation_split=0.2, callbacks=[hook]
+                x_train, y_train, batch_size=64, epochs=2, validation_split=0.2, callbacks=[hook]
             )
             test_scores = model.evaluate(x_test, y_test, verbose=2, callbacks=[hook])
         else:
             model.compile(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
-            history = model.fit(x_train, y_train, epochs=5, batch_size=64, validation_split=0.2)
+            history = model.fit(x_train, y_train, epochs=2, batch_size=64, validation_split=0.2)
             test_scores = model.evaluate(x_test, y_test, verbose=2)
 
         hook = smd.get_hook()


### PR DESCRIPTION
### Description of changes:
Executing gradtape and keras fit() tests led to a slowdown indicated by `WARNING:tensorflow:Method (on_train_batch_end) is slow compared to the batch update (0.145641). Check your callbacks.`

This occurred only on c4.8x, c5.18x instances.

After multiple experiments, we are splitting the gradienttape and fit() tests into 2 separate files as it seems that there is some state from the GradientTape training that is not getting cleared before fit() training starts. This slowdown in callback was observed even when no smdebug changes were made to the training script.

Below results are for a run of 5 epochs per test

Test results (tests executed in TF 2.1 WIP DLC on c4.8xlarge instance):

`time timeout 600s python tests/zero_code_change_tensorflow2_gradtape_integration_tests.py`
real    2m32.678s
user    3m14.783s
sys     0m9.669s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_integration_tests.py`
real    6m41.652s
user    50m31.547s
sys     162m40.373s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py --script-mode`
real    3m6.795s
user    3m31.127s
sys     0m29.912s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_integration_tests.py --script-mode`
real    7m4.844s
user    53m52.965s
sys     173m53.885s


Tests executed in TF 2.1 WIP GPU DLC on p3.8xlarge:

If the following tests are the first to be executed in a container, they show the following times:
`time timeout 600s python mock/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py`
real    9m30.022s
user    9m48.376s
sys     0m8.984s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_integration_tests.py`
real    8m27.949s
user    37m41.880s
sys     165m20.208s

Subsequent runs show the following numbers:
`time timeout 600s python mock/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py`
real    4m8.980s
user    4m26.708s
sys     0m9.328s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py --script-mode`
real    4m4.651s
user    4m40.912s
sys     3m57.780s

`time timeout 600s python mock/tests/zero_code_change/tensorflow2_integration_tests.py --script-mode`
real    8m24.723s
user    39m14.620s
sys     175m2.184s

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
