### PR TITLE
Remove duplicate loss registration

### DIFF
--- a/config/tests.sh
+++ b/config/tests.sh
@@ -25,6 +25,7 @@ run_for_framework() {
       elif [ "$1" = "tensorflow" ] ; then
         python tests/zero_code_change/tensorflow_integration_tests.py
       elif [ "$1" = "tensorflow2" ] ; then
+        python tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
         python tests/zero_code_change/tensorflow2_integration_tests.py
       fi
 

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -895,8 +895,6 @@ class CallbackHook(BaseHook):
         # Do not register loss if already registered
         # This happens when explicitly saving loss functional
         # with AWS Pytorch.
-        if name == "nll_loss" and idx == 1:
-            return
         self.written_tensor_name_for_step[tensor_name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -892,6 +892,8 @@ class CallbackHook(BaseHook):
     def _write_outputs(self, name, outputs):
         tensor_name = name + CallbackHook.OUTPUT_TENSOR_SUFFIX
         idx = self.written_tensor_name_for_step.get(tensor_name, 0)
+        if name == "nll_loss" and idx == 1:
+            return 
         self.written_tensor_name_for_step[tensor_name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -892,8 +892,11 @@ class CallbackHook(BaseHook):
     def _write_outputs(self, name, outputs):
         tensor_name = name + CallbackHook.OUTPUT_TENSOR_SUFFIX
         idx = self.written_tensor_name_for_step.get(tensor_name, 0)
+        # Do not register loss if already registered
+        # This happens when explicitly saving loss functional
+        # with AWS Pytorch.
         if name == "nll_loss" and idx == 1:
-            return 
+            return
         self.written_tensor_name_for_step[tensor_name] = self._write(
             name, outputs, CallbackHook.OUTPUT_TENSOR_SUFFIX, idx=idx
         )

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -140,11 +140,14 @@ class Hook(CallbackHook):
             self.export_collections()
             self.exported_collections = True
 
-    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor) -> None:
+    def record_tensor_value(self, tensor_name: str, tensor_value: torch.Tensor, is_loss=False) -> None:
         """Used for registering functional directly, such as F.mse_loss()."""
         assert isinstance(
             tensor_value, torch.Tensor
         ), f"tensor_value={tensor_value} must be torch.Tensor"
+
+        if is_loss is True:
+            self.has_registered_loss_module = True
 
         self._write_outputs(tensor_name, tensor_value)
 

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -43,10 +43,7 @@ def create_net_and_train(out_dir, n_steps, use_loss_module=False, use_loss_funct
     optimizer = optim.SGD(net.parameters(), lr=0.05, momentum=0.9)
     criterion = nn.CrossEntropyLoss()
 
-    hook = Hook(
-        out_dir=out_dir,
-        save_config=SaveConfig(save_interval=1),
-    )
+    hook = Hook(out_dir=out_dir, save_config=SaveConfig(save_interval=1))
     hook.register_module(net)
     if use_loss_module:
         hook.register_loss(criterion)

--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 # First Party
-import smdebug.pytorch as smd
+from smdebug.pytorch import Hook, SaveConfig
 from smdebug.trials import create_trial
 
 
@@ -43,7 +43,10 @@ def create_net_and_train(out_dir, n_steps, use_loss_module=False, use_loss_funct
     optimizer = optim.SGD(net.parameters(), lr=0.05, momentum=0.9)
     criterion = nn.CrossEntropyLoss()
 
-    hook = smd.Hook(out_dir=out_dir, save_config=smd.SaveConfig(save_interval=1))
+    hook = Hook(
+        out_dir=out_dir,
+        save_config=SaveConfig(save_interval=1),
+    )
     hook.register_module(net)
     if use_loss_module:
         hook.register_loss(criterion)
@@ -64,7 +67,6 @@ def create_net_and_train(out_dir, n_steps, use_loss_module=False, use_loss_funct
 
     # Users can call this method to immediately use the Trials API.
     hook.close()
-    smd.del_hook()
 
 
 @pytest.mark.slow  # 0:05 to run
@@ -78,8 +80,8 @@ def test_register_loss_functional(out_dir):
     loss_tensor = trial.tensor("nll_loss_output_0")
 
     # Capture ['nll_loss_output_0']
-    assert len(trial.tensor_names()) == 2
-    assert len(loss_coll.tensor_names) == 2
+    assert len(trial.tensor_names()) == 1
+    assert len(loss_coll.tensor_names) == 1
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps

--- a/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_gradtape_integration_tests.py
@@ -1,0 +1,169 @@
+"""
+WARNING: This test is useful for DLC testing.
+
+Test with Keras GradientTape.
+
+We check that certain tensors are saved.
+Here in the test suite we delete the hook after every script.
+"""
+# Standard Library
+import argparse
+
+# Third Party
+import tensorflow.compat.v2 as tf
+
+# First Party
+import smdebug.tensorflow as smd
+from smdebug.core.utils import SagemakerSimulator
+
+
+def get_keras_data():
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+    return (x_train, y_train), (x_test, y_test)
+
+
+def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_contents="{}"):
+    """ Test the default ZCC behavior of saving losses and metrics in eager and non-eager modes."""
+    smd.del_hook()
+    tf.keras.backend.clear_session()
+
+    with SagemakerSimulator(json_file_contents=json_file_contents) as sim:
+        model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Flatten(input_shape=(28, 28, 1)),  # WA for TF issue #36279
+                tf.keras.layers.Dense(128, activation="relu"),
+                tf.keras.layers.Dropout(0.2),
+                tf.keras.layers.Dense(10, activation="softmax"),
+            ]
+        )
+        (x_train, y_train), _ = get_keras_data()
+        dataset = tf.data.Dataset.from_tensor_slices(
+            (tf.cast(x_train[..., tf.newaxis] / 255, tf.float32), tf.cast(y_train, tf.int64))
+        )
+        dataset = dataset.shuffle(1000).batch(64)
+
+        opt = tf.keras.optimizers.RMSprop()
+        cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+        train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
+        n_epochs = 2
+        if script_mode:
+            if json_file_contents == "{}":
+                hook = smd.KerasHook(out_dir=sim.out_dir, export_tensorboard=True)
+            else:
+                hook = smd.KerasHook.create_from_json_file()
+
+            for epoch in range(n_epochs):
+                print("Epoch %d/%d" % (epoch + 1, n_epochs))
+                for data, labels in dataset:
+                    dataset_labels = labels
+                    labels = tf.one_hot(labels, depth=10)
+                    with hook.wrap_tape(tf.GradientTape()) as tape:
+                        logits = model(data, training=True)  # (32,10)
+                        loss_value = cce(labels, logits)
+                    grads = tape.gradient(loss_value, model.variables)
+                    opt.apply_gradients(zip(grads, model.variables))
+                    acc = train_acc_metric(dataset_labels, logits)
+                    hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
+                log = "Epoch %d " % (epoch + 1)
+                log += "Accuracy %.4f" % train_acc_metric.result()
+                print(log)
+                train_acc_metric.reset_states()
+            hook = smd.get_hook()
+            assert hook
+            hook.close()
+            # Check that hook created and tensors saved
+            trial = smd.create_trial(path=sim.out_dir)
+            assert len(trial.steps()) > 0, "Nothing saved at any step."
+            assert len(trial.tensor_names()) > 0, "Tensors were not saved."
+            assert len(trial.tensor_names(collection="losses")) > 0
+        else:
+            # ZCC doesn't support yet (as of smdebug v0.7.2)
+            for epoch in range(n_epochs):
+                print("Epoch %d/%d" % (epoch + 1, n_epochs))
+                for data, labels in dataset:
+                    dataset_labels = labels
+                    labels = tf.one_hot(labels, depth=10)
+                    with tf.GradientTape(persistent=True) as tape:
+                        logits = model(data, training=True)  # (32,10)
+                        loss_value = cce(labels, logits)
+                    grads = tape.gradient(loss_value, model.variables)
+                    opt.apply_gradients(zip(grads, model.variables))
+                    acc = train_acc_metric(dataset_labels, logits)
+                log = "Epoch %d " % (epoch + 1)
+                log += "Accuracy %.4f" % train_acc_metric.result()
+                print(log)
+                train_acc_metric.reset_states()
+            hook = smd.get_hook()
+            assert not hook
+
+
+def test_keras_v2_default(script_mode: bool = False):
+    # Test default ZCC behavior
+    helper_test_keras_v2_gradienttape(script_mode=script_mode)
+
+
+def test_keras_v2_multi_collections(script_mode: bool = False):
+    # Test multiple collections included in hook json
+    json_file_contents = """
+            {
+                "S3OutputPath": "s3://sagemaker-test",
+                "LocalPath": "/opt/ml/output/tensors",
+                "HookParameters" : {
+                    "save_interval": "100",
+                    "include_workers": "all"
+                },
+                "CollectionConfigurations": [
+                    {
+                        "CollectionName": "gradients"
+                    },
+                    {
+                        "CollectionName": "weights"
+                    },
+                    {
+                        "CollectionName": "losses"
+                    },
+                    {
+                        "CollectionName": "biases"
+                    },
+                    {
+                        "CollectionName": "optimizer_variables"
+                    }
+                ]
+            }
+            """
+    helper_test_keras_v2_gradienttape(
+        script_mode=script_mode, json_file_contents=json_file_contents
+    )
+
+
+def test_keras_v2_save_all(script_mode: bool = False):
+    # Test save all through hook config
+    json_file_contents = """
+            {
+                "S3OutputPath": "s3://sagemaker-test",
+                "LocalPath": "/opt/ml/output/tensors",
+                "HookParameters" : {
+                    "save_steps": "0,1,2,3",
+                    "save_all": true
+                }
+            }
+            """
+    helper_test_keras_v2_gradienttape(
+        script_mode=script_mode, json_file_contents=json_file_contents
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--script-mode", help="Manually create hooks instead of relying on ZCC", action="store_true"
+    )
+    args = parser.parse_args()
+    script_mode = args.script_mode
+
+    # Gradient Tape eager mode
+    test_keras_v2_default(script_mode)
+    test_keras_v2_multi_collections(script_mode)
+    test_keras_v2_save_all(script_mode)

--- a/tests/zero_code_change/tensorflow2_integration_tests.py
+++ b/tests/zero_code_change/tensorflow2_integration_tests.py
@@ -63,14 +63,14 @@ def helper_test_keras_v2(script_mode: bool = False, eager_mode: bool = True):
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
             history = model.fit(
-                x_train, y_train, batch_size=64, epochs=5, validation_split=0.2, callbacks=[hook]
+                x_train, y_train, batch_size=64, epochs=2, validation_split=0.2, callbacks=[hook]
             )
             test_scores = model.evaluate(x_test, y_test, verbose=2, callbacks=[hook])
         else:
             model.compile(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
-            history = model.fit(x_train, y_train, batch_size=64, epochs=5, validation_split=0.2)
+            history = model.fit(x_train, y_train, batch_size=64, epochs=2, validation_split=0.2)
             test_scores = model.evaluate(x_test, y_test, verbose=2)
 
         hook = smd.get_hook()
@@ -104,14 +104,14 @@ def helper_test_keras_v2_json_config(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
             history = model.fit(
-                x_train, y_train, batch_size=64, epochs=5, validation_split=0.2, callbacks=[hook]
+                x_train, y_train, batch_size=64, epochs=2, validation_split=0.2, callbacks=[hook]
             )
             test_scores = model.evaluate(x_test, y_test, verbose=2, callbacks=[hook])
         else:
             model.compile(
                 loss="sparse_categorical_crossentropy", optimizer=opt, metrics=["accuracy"]
             )
-            history = model.fit(x_train, y_train, epochs=5, batch_size=64, validation_split=0.2)
+            history = model.fit(x_train, y_train, epochs=2, batch_size=64, validation_split=0.2)
             test_scores = model.evaluate(x_test, y_test, verbose=2)
 
         hook = smd.get_hook()
@@ -127,77 +127,8 @@ def helper_test_keras_v2_json_config(
         assert len(trial.tensor_names(collection="losses")) > 0
 
 
-def helper_test_keras_v2_gradienttape(script_mode: bool = False, json_file_contents="{}"):
-    """ Test the default ZCC behavior of saving losses and metrics in eager and non-eager modes."""
-    smd.del_hook()
-    tf.keras.backend.clear_session()
-
-    with SagemakerSimulator(json_file_contents=json_file_contents) as sim:
-        model = tf.keras.models.Sequential(
-            [
-                tf.keras.layers.Flatten(input_shape=(28, 28, 1)),  # WA for TF issue #36279
-                tf.keras.layers.Dense(128, activation="relu"),
-                tf.keras.layers.Dropout(0.2),
-                tf.keras.layers.Dense(10, activation="softmax"),
-            ]
-        )
-        (x_train, y_train), _ = get_keras_data()
-        dataset = tf.data.Dataset.from_tensor_slices(
-            (tf.cast(x_train[..., tf.newaxis] / 255, tf.float32), tf.cast(y_train, tf.int64))
-        )
-        dataset = dataset.shuffle(1000).batch(64)
-
-        opt = tf.keras.optimizers.RMSprop()
-        cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
-        train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-        n_epochs = 5
-        if script_mode:
-            if json_file_contents == "{}":
-                hook = smd.KerasHook(out_dir=sim.out_dir, export_tensorboard=True)
-            else:
-                hook = smd.KerasHook.create_from_json_file()
-
-            for epoch in range(n_epochs):
-                for data, labels in dataset:
-                    dataset_labels = labels
-                    labels = tf.one_hot(labels, depth=10)
-                    with hook.wrap_tape(tf.GradientTape()) as tape:
-                        logits = model(data, training=True)  # (32,10)
-                        loss_value = cce(labels, logits)
-                    grads = tape.gradient(loss_value, model.variables)
-                    opt.apply_gradients(zip(grads, model.variables))
-                    acc = train_acc_metric(dataset_labels, logits)
-                    hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
-                train_acc_metric.reset_states()
-            hook = smd.get_hook()
-            assert hook
-            hook.close()
-            # Check that hook created and tensors saved
-            trial = smd.create_trial(path=sim.out_dir)
-            assert len(trial.steps()) > 0, "Nothing saved at any step."
-            assert len(trial.tensor_names()) > 0, "Tensors were not saved."
-            assert len(trial.tensor_names(collection="losses")) > 0
-        else:
-            # ZCC doesn't support yet (as of smdebug v0.7.2)
-            for epoch in range(n_epochs):
-                for data, labels in dataset:
-                    dataset_labels = labels
-                    labels = tf.one_hot(labels, depth=10)
-                    with tf.GradientTape(persistent=True) as tape:
-                        logits = model(data, training=True)  # (32,10)
-                        loss_value = cce(labels, logits)
-                    grads = tape.gradient(loss_value, model.variables)
-                    opt.apply_gradients(zip(grads, model.variables))
-                    acc = train_acc_metric(dataset_labels, logits)
-                train_acc_metric.reset_states()
-            hook = smd.get_hook()
-            assert not hook
-
-
 def test_keras_v2_default(script_mode: bool = False, eager_mode: bool = True):
     # Test default ZCC behavior
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(script_mode=script_mode)
     helper_test_keras_v2(script_mode=script_mode, eager_mode=eager_mode)
 
 
@@ -230,10 +161,6 @@ def test_keras_v2_multi_collections(script_mode: bool = False, eager_mode: bool 
                 ]
             }
             """
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(
-            script_mode=script_mode, json_file_contents=json_file_contents
-        )
     helper_test_keras_v2_json_config(
         script_mode=script_mode, eager_mode=eager_mode, json_file_contents=json_file_contents
     )
@@ -251,10 +178,6 @@ def test_keras_v2_save_all(script_mode: bool = False, eager_mode: bool = True):
                 }
             }
             """
-    if eager_mode:
-        helper_test_keras_v2_gradienttape(
-            script_mode=script_mode, json_file_contents=json_file_contents
-        )
     helper_test_keras_v2_json_config(
         script_mode=script_mode, eager_mode=eager_mode, json_file_contents=json_file_contents
     )


### PR DESCRIPTION
### Description of changes:

- loss functional values are saved twice for each step with AWS Pytorch.
- This happens because functional losses are saved by default by the post_hook_for_loss_functional fn in AWS Pytorch.



#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
