### PR TITLE
Install Protobuf on OSX

### DIFF
--- a/config/protoc_downloader.sh
+++ b/config/protoc_downloader.sh
@@ -4,7 +4,7 @@ case "${unameOut}" in
     Linux*)     machine=Linux;;
     Darwin*)    machine=Mac;;
 esac
-if [ "$machine" == "Mac" ] ; then
+if [ "$machine" = "Mac" ] ; then
     PROTOC_ZIP=protoc-3.7.1-osx-x86_64.zip
     brew install unzip
 else

--- a/config/protoc_downloader.sh
+++ b/config/protoc_downloader.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
-apt-get install sudo
-sudo apt-get install unzip
-PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     machine=Linux;;
+    Darwin*)    machine=Mac;;
+esac
+if [ "$machine" == "Mac" ] ; then
+    PROTOC_ZIP=protoc-3.7.1-osx-x86_64.zip
+    brew install unzip
+else
+    PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
+    apt-get install sudo
+    sudo apt-get install unzip
+fi
 curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
 unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
 unzip -o $PROTOC_ZIP -d /usr/local include/*


### PR DESCRIPTION
### Description of changes:
- added a check to determine platform before downloading the protobuf zip to allow OSX users to use the `protoc_downloader.sh` script

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
