### PR TITLE
Paranthesize assert statements

### DIFF
--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -13,6 +13,7 @@ from re import search
 import pytest
 import tensorflow.compat.v2 as tf
 from tests.tensorflow.utils import create_trial_fast_refresh
+from tests.tensorflow2.utils import is_tf_2_2
 
 # First Party
 import smdebug.tensorflow as smd
@@ -22,19 +23,6 @@ from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.exceptions import TensorUnavailableForStep
 from smdebug.tensorflow import ReductionConfig, SaveConfig
-
-
-def is_tf_2_2():
-    """
-    TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections.
-    where 'batch' is the batch number and size is the batch size.
-    But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total
-    number of tensor_names emitted by 1.
-    :return: bool
-    """
-    if search("2.2..", tf.__version__):
-        return True
-    return False
 
 
 def helper_keras_fit(

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -410,18 +410,19 @@ def test_keras_fit(out_dir, tf_eager_mode, saveall):
     # can't save gradients in TF 2.x eager mode
     if saveall:  # save losses, metrics, weights, biases
         if tf_eager_mode:
-            assert len(trial.tensor_names()) == 7 if is_tf_2_2() else 8
+            assert len(trial.tensor_names()) == (7 if is_tf_2_2() else 8)
         else:
             assert len(trial.tensor_names()) == 21
         assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     else:  # save the default losses and metrics
-        assert len(trial.tensor_names()) == 3 if is_tf_2_2() and tf_eager_mode else 4
+        assert len(trial.tensor_names()) == (3 if is_tf_2_2() and tf_eager_mode else 4)
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
     assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
         if is_tf_2_2() and tf_eager_mode
         else 3
+                                                                       )
     )
 
 
@@ -515,7 +516,7 @@ def test_clash_with_tb_callback(out_dir):
         add_callbacks=["tensorboard"],
     )
     tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.tensor_names()) == 7 if is_tf_2_2() else 8
+    assert len(tr.tensor_names()) == (7 if is_tf_2_2() else 8)
 
 
 @pytest.mark.slow
@@ -538,14 +539,15 @@ def test_weights_collections(out_dir, tf_eager_mode):
 
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
-    assert len(trial.tensor_names()) == 5 if is_tf_2_2() and tf_eager_mode else 6
+    assert len(trial.tensor_names()) == (5 if is_tf_2_2() and tf_eager_mode else 6)
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
     assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
         if is_tf_2_2() and tf_eager_mode
         else 3
+                                                                       )
     )
 
 
@@ -572,7 +574,7 @@ def test_include_collections(out_dir, tf_eager_mode):
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
     if tf_eager_mode:
-        assert len(trial.tensor_names()) == 7 if is_tf_2_2() else 8
+        assert len(trial.tensor_names()) == (7 if is_tf_2_2() else 8)
     else:
         assert len(trial.tensor_names()) == 18
         assert len(trial.tensor_names(collection=CollectionKeys.GRADIENTS)) == 4
@@ -581,9 +583,10 @@ def test_include_collections(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
     assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
         if is_tf_2_2() and tf_eager_mode
         else 3
+                                                                       )
     )
 
 
@@ -598,12 +601,13 @@ def test_hook_from_json(out_dir, tf_eager_mode, monkeypatch):
 
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
-    assert len(trial.tensor_names()) == 5 if is_tf_2_2() and tf_eager_mode else 6
+    assert len(trial.tensor_names()) == (5 if is_tf_2_2() and tf_eager_mode else 6)
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
     assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == 2
+        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
         if is_tf_2_2() and tf_eager_mode
         else 3
+                                                                       )
     )

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -6,14 +6,11 @@ before pushing to master.
 This was tested with TensorFlow 2.1, by running
 `python tests/tensorflow2/test_keras.py` from the main directory.
 """
-# Standard Library
-from re import search
-
 # Third Party
 import pytest
 import tensorflow.compat.v2 as tf
-from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.tensorflow2.utils import is_tf_2_2
+from tests.tensorflow.utils import create_trial_fast_refresh
 
 # First Party
 import smdebug.tensorflow as smd
@@ -406,11 +403,8 @@ def test_keras_fit(out_dir, tf_eager_mode, saveall):
     else:  # save the default losses and metrics
         assert len(trial.tensor_names()) == (3 if is_tf_2_2() and tf_eager_mode else 4)
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
-        if is_tf_2_2() and tf_eager_mode
-        else 3
-                                                                       )
+    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (
+        2 if is_tf_2_2() and tf_eager_mode else 3
     )
 
 
@@ -531,11 +525,8 @@ def test_weights_collections(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
-        if is_tf_2_2() and tf_eager_mode
-        else 3
-                                                                       )
+    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (
+        2 if is_tf_2_2() and tf_eager_mode else 3
     )
 
 
@@ -570,11 +561,8 @@ def test_include_collections(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
-        if is_tf_2_2() and tf_eager_mode
-        else 3
-                                                                       )
+    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (
+        2 if is_tf_2_2() and tf_eager_mode else 3
     )
 
 
@@ -593,9 +581,6 @@ def test_hook_from_json(out_dir, tf_eager_mode, monkeypatch):
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
-    assert (
-        len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (2
-        if is_tf_2_2() and tf_eager_mode
-        else 3
-                                                                       )
+    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) == (
+        2 if is_tf_2_2() and tf_eager_mode else 3
     )

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -158,8 +158,9 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     if include_workers == "all":
         assert len(tr.workers()) == strategy.num_replicas_in_sync
         if eager:
-            assert len(tr.tensor_names()) == (6 + 3 + 1)
-            # 6 weights, 1 loss, 3 metrics
+            assert len(tr.tensor_names()) == (6 + 1 + 2 if is_tf_2_2() else 6 + 1 + 3)
+            # 6 weights, 1 loss, 3 metrics for Tf 2.1
+            # 6 weights, 1 loss, 2 metrics for Tf 2.1
         else:
             assert len(tr.tensor_names()) == (6 + 6 + 1 + 3 + strategy.num_replicas_in_sync * 3 + 5)
     else:
@@ -244,7 +245,7 @@ def test_save_all(out_dir, tf_eager_mode):
     tr = create_trial_fast_refresh(out_dir)
     print(tr.tensor_names())
     if tf_eager_mode:
-        assert len(tr.tensor_names()) == (5 + 1 + 3 if is_tf_2_2() else 6 + 1 + 3)
+        assert len(tr.tensor_names()) == (6 + 2 + 1 if is_tf_2_2() else 6 + 3 + 1)
         # weights, metrics, losses
     else:
         assert (

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -160,7 +160,7 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
         if eager:
             assert len(tr.tensor_names()) == (6 + 1 + 2 if is_tf_2_2() else 6 + 1 + 3)
             # 6 weights, 1 loss, 3 metrics for Tf 2.1
-            # 6 weights, 1 loss, 2 metrics for Tf 2.1
+            # 6 weights, 1 loss, 2 metrics for Tf 2.2
         else:
             assert len(tr.tensor_names()) == (6 + 6 + 1 + 3 + strategy.num_replicas_in_sync * 3 + 5)
     else:

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -9,8 +9,8 @@ import pytest
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 from tensorflow.python.client import device_lib
-from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.tensorflow2.utils import is_tf_2_2
+from tests.tensorflow.utils import create_trial_fast_refresh
 
 # First Party
 import smdebug.tensorflow as smd

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -224,7 +224,7 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     assert len(tr.tensor(loss_name).steps()) == 12
 
     metricnames = tr.tensor_names(collection=CollectionKeys.METRICS)
-    assert len(metricnames) == 3
+    assert len(metricnames) == (2 if is_tf_2_2() else 3)
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -10,6 +10,7 @@ import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 from tensorflow.python.client import device_lib
 from tests.tensorflow.utils import create_trial_fast_refresh
+from tests.tensorflow2.utils import is_tf_2_2
 
 # First Party
 import smdebug.tensorflow as smd
@@ -243,7 +244,7 @@ def test_save_all(out_dir, tf_eager_mode):
     tr = create_trial_fast_refresh(out_dir)
     print(tr.tensor_names())
     if tf_eager_mode:
-        assert len(tr.tensor_names()) == 6 + 1 + 3
+        assert len(tr.tensor_names()) == (5 + 1 + 3 if is_tf_2_2() else 6 + 1 + 3)
         # weights, metrics, losses
     else:
         assert (
@@ -426,7 +427,7 @@ def test_clash_with_tb_callback(out_dir):
         add_callbacks=["tensorboard"],
     )
     tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.tensor_names()) == 10
+    assert len(tr.tensor_names()) == (9 if is_tf_2_2() else 10)
 
 
 def test_one_device(out_dir, tf_eager_mode):

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -1,4 +1,7 @@
+# Standard Library
 from re import search
+
+# Third Party
 import tensorflow.compat.v2 as tf
 
 

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -1,0 +1,15 @@
+from re import search
+import tensorflow.compat.v2 as tf
+
+
+def is_tf_2_2():
+    """
+    TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections.
+    where 'batch' is the batch number and size is the batch size.
+    But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total
+    number of tensor_names emitted by 1.
+    :return: bool
+    """
+    if search("2.2..", tf.__version__):
+        return True
+    return False


### PR DESCRIPTION
### Description of changes:
- Bug in the way the assert statements were written.
- The parentheses ensures that the if else block is evaluated first.
- Also refactored the code to reuse the `is_tf_2_2` fn

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
