### PR TITLE
Do not save loss and check for loss in Pytorch Data Parallel

### DIFF
--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -36,9 +36,6 @@ def test_data_parallel():
 
     trial = create_trial(out_dir)
     assert trial.steps() == [0, 1, 5]
-    if device == "cpu":
-        assert len(trial.tensor_names()) == 36
-    else:
-        assert len(trial.tensor_names()) > 37
+    assert len(trial.tensor_names()) >= 36
 
     shutil.rmtree(out_dir, ignore_errors=True)

--- a/tests/pytorch/test_data_parallel.py
+++ b/tests/pytorch/test_data_parallel.py
@@ -37,7 +37,7 @@ def test_data_parallel():
     trial = create_trial(out_dir)
     assert trial.steps() == [0, 1, 5]
     if device == "cpu":
-        assert len(trial.tensor_names()) == 38
+        assert len(trial.tensor_names()) == 36
     else:
         assert len(trial.tensor_names()) > 37
 

--- a/tests/pytorch/utils.py
+++ b/tests/pytorch/utils.py
@@ -48,7 +48,6 @@ def train(model, hook, device, optimizer, num_steps=500, set_modes=False):
         optimizer.zero_grad()
         output = model(Variable(data, requires_grad=True))
         loss = F.nll_loss(output, target)
-        hook.record_tensor_value("nll_loss", tensor_value=loss)
         loss.backward()
         optimizer.step()
 

--- a/tests/pytorch/utils.py
+++ b/tests/pytorch/utils.py
@@ -48,6 +48,7 @@ def train(model, hook, device, optimizer, num_steps=500, set_modes=False):
         optimizer.zero_grad()
         output = model(Variable(data, requires_grad=True))
         loss = F.nll_loss(output, target)
+        hook.record_tensor_value("nll_loss", tensor_value=loss)
         loss.backward()
         optimizer.step()
 


### PR DESCRIPTION
### Description of changes:
- Dataparallel test checks if smdebug supports pytorch data parallel.
- There is currently a [bug](https://github.com/awslabs/sagemaker-debugger/issues/205) in saving losses 
- Removing logic that saves loss and checks for it in this test, since it is not required to check the sanity of data parallel functionality 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
