### PR TITLE
TF2 examples

### DIFF
--- a/examples/tensorflow2/README.md
+++ b/examples/tensorflow2/README.md
@@ -1,0 +1,22 @@
+# Examples
+## Example notebooks
+Please refer to the example notebooks in [Amazon SageMaker Examples repository](https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-debugger)
+
+## Example scripts
+The above notebooks come with example scripts which can be used through SageMaker. Some more example scripts are here in [scripts/](scripts/)
+
+## Example configurations for saving tensors through [SageMaker Python SDK](https://github.com/aws/sagemaker-python-sdk)
+Example configurations for saving tensors through the hook are available at [docs/sagemaker.md](../docs/sagemaker.md)
+
+## Example configurations for running rules through [SageMaker Python SDK](https://github.com/aws/sagemaker-python-sdk)
+Example configurations for saving tensors through the hook are available at [docs/sagemaker.md](../docs/sagemaker.md)
+
+## Example for running rule locally
+
+```
+from smdebug.rules import invoke_rule
+from smdebug.trials import create_trial
+trial = create_trial('s3://bucket/prefix')
+rule_obj = CustomRule(trial, param=value)
+invoke_rule(rule_obj, start_step=0, end_step=10)
+```

--- a/examples/tensorflow2/scripts/tf_keras_fit_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_eager.py
@@ -62,6 +62,7 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
+        # Information on default collections https://github.com/awslabs/sagemaker-debugger/blob/master/docs/api.md#default-collections-saved
         include_collections=["weights", "biases", "default"],
         save_config=smd.SaveConfig(save_interval=opt.save_interval),
     )

--- a/examples/tensorflow2/scripts/tf_keras_fit_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_eager.py
@@ -3,7 +3,6 @@ This script is a ResNet training script which uses Tensorflow's Keras interface.
 It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
 Here, the hook has been created using its constructor to allow running this locally for your experimentation.
 When you want to run this script in SageMaker, it is recommended to create the hook from json file.
-Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
 """
 
 # Standard Library

--- a/examples/tensorflow2/scripts/tf_keras_fit_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_eager.py
@@ -1,0 +1,81 @@
+"""
+This script is a ResNet training script which uses Tensorflow's Keras interface.
+It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
+Here, the hook has been created using its constructor to allow running this locally for your experimentation.
+When you want to run this script in SageMaker, it is recommended to create the hook from json file.
+Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
+"""
+
+# Standard Library
+import argparse
+
+# Third Party
+import numpy as np
+import tensorflow.compat.v2 as tf
+from tensorflow.keras.applications.resnet50 import ResNet50
+from tensorflow.keras.datasets import cifar10
+from tensorflow.keras.utils import to_categorical
+
+# First Party
+import smdebug.tensorflow as smd
+
+
+def train(batch_size, epoch, model, hook):
+    (X_train, y_train), (X_valid, y_valid) = cifar10.load_data()
+
+    Y_train = to_categorical(y_train, 10)
+    Y_valid = to_categorical(y_valid, 10)
+
+    X_train = X_train.astype("float32")
+    X_valid = X_valid.astype("float32")
+
+    mean_image = np.mean(X_train, axis=0)
+    X_train -= mean_image
+    X_valid -= mean_image
+    X_train /= 128.0
+    X_valid /= 128.0
+
+    model.fit(
+        X_train,
+        Y_train,
+        batch_size=batch_size,
+        epochs=epoch,
+        validation_data=(X_valid, Y_valid),
+        shuffle=True,
+        ##### Enabling SageMaker Debugger ###########
+        # adding hook as a callback
+        callbacks=[hook],
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train resnet50 cifar10")
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--epoch", type=int, default=3)
+    parser.add_argument("--model_dir", type=str, default="./model_keras_resnet")
+    parser.add_argument("--out_dir", type=str)
+    parser.add_argument("--save_interval", type=int, default=500)
+    opt = parser.parse_args()
+
+    model = ResNet50(weights=None, input_shape=(32, 32, 3), classes=10)
+
+    ##### Enabling SageMaker Debugger ###########
+    # creating hook
+    hook = smd.KerasHook(
+        out_dir=opt.out_dir,
+        include_collections=["weights", "biases", "default"],
+        save_config=smd.SaveConfig(save_interval=opt.save_interval),
+    )
+
+    optimizer = tf.keras.optimizers.Adam()
+
+    ##### Enabling SageMaker Debugger ###########
+    # wrap the optimizer so the hook can identify the gradients
+    model.compile(loss="categorical_crossentropy", optimizer=optimizer, metrics=["accuracy"])
+
+    # start the training.
+    train(opt.batch_size, opt.epoch, model, hook)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tensorflow2/scripts/tf_keras_fit_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_eager.py
@@ -34,6 +34,11 @@ def train(batch_size, epoch, model, hook):
     X_train /= 128.0
     X_valid /= 128.0
 
+    # save_scalar() API can be used to save arbitrary scalar values that may
+    # or may not be related to training.
+    # Ref: https://github.com/awslabs/sagemaker-debugger/blob/master/docs/api.md#common-hook-api
+    hook.save_scalar("epoch", epoch, sm_metric=True)
+
     model.fit(
         X_train,
         Y_train,
@@ -45,6 +50,8 @@ def train(batch_size, epoch, model, hook):
         # adding hook as a callback
         callbacks=[hook],
     )
+
+    hook.save_scalar("batch_size", batch_size, sm_metric=True)
 
 
 def main():

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -3,7 +3,6 @@ This script is a ResNet training script which uses Tensorflow's Keras interface.
 It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
 Here, the hook has been created using its constructor to allow running this locally for your experimentation.
 When you want to run this script in SageMaker, it is recommended to create the hook from json file.
-Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
 """
 
 # Standard Library
@@ -65,7 +64,8 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
-        save_all=True,
+        include_collections=["weights", "biases", "default", "gradients",
+                             "optimizer_variables", "inputs", "outputs"],
         save_config=smd.SaveConfig(save_interval=opt.save_interval),
     )
 

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -1,0 +1,83 @@
+"""
+This script is a ResNet training script which uses Tensorflow's Keras interface.
+It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
+Here, the hook has been created using its constructor to allow running this locally for your experimentation.
+When you want to run this script in SageMaker, it is recommended to create the hook from json file.
+Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
+"""
+
+# Standard Library
+import argparse
+
+# Third Party
+import numpy as np
+import tensorflow.compat.v2 as tf
+from tensorflow.keras.applications.resnet50 import ResNet50
+from tensorflow.keras.datasets import cifar10
+from tensorflow.keras.utils import to_categorical
+
+# First Party
+import smdebug.tensorflow as smd
+
+tf.compat.v1.disable_eager_execution()
+
+
+def train(batch_size, epoch, model, hook):
+    (X_train, y_train), (X_valid, y_valid) = cifar10.load_data()
+
+    Y_train = to_categorical(y_train, 10)
+    Y_valid = to_categorical(y_valid, 10)
+
+    X_train = X_train.astype("float32")
+    X_valid = X_valid.astype("float32")
+
+    mean_image = np.mean(X_train, axis=0)
+    X_train -= mean_image
+    X_valid -= mean_image
+    X_train /= 128.0
+    X_valid /= 128.0
+
+    model.fit(
+        X_train,
+        Y_train,
+        batch_size=batch_size,
+        epochs=epoch,
+        validation_data=(X_valid, Y_valid),
+        shuffle=True,
+        ##### Enabling SageMaker Debugger ###########
+        # adding hook as a callback
+        callbacks=[hook],
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train resnet50 cifar10")
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--epoch", type=int, default=3)
+    parser.add_argument("--model_dir", type=str, default="./model_keras_resnet")
+    parser.add_argument("--out_dir", type=str)
+    parser.add_argument("--save_interval", type=int, default=500)
+    opt = parser.parse_args()
+
+    model = ResNet50(weights=None, input_shape=(32, 32, 3), classes=10)
+
+    ##### Enabling SageMaker Debugger ###########
+    # creating hook
+    hook = smd.KerasHook(
+        out_dir=opt.out_dir,
+        include_collections=["weights", "biases", "default"],
+        save_config=smd.SaveConfig(save_interval=opt.save_interval),
+    )
+
+    optimizer = tf.keras.optimizers.Adam()
+
+    ##### Enabling SageMaker Debugger ###########
+    # wrap the optimizer so the hook can identify the gradients
+    model.compile(loss="categorical_crossentropy", optimizer=optimizer, metrics=["accuracy"])
+
+    # start the training.
+    train(opt.batch_size, opt.epoch, model, hook)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -64,8 +64,15 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
-        include_collections=["weights", "biases", "default", "gradients",
-                             "optimizer_variables", "inputs", "outputs"],
+        include_collections=[
+            "weights",
+            "biases",
+            "default",
+            "gradients",
+            "optimizer_variables",
+            "inputs",
+            "outputs",
+        ],
         save_config=smd.SaveConfig(save_interval=opt.save_interval),
     )
 

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -78,7 +78,6 @@ def main():
             "default",
             "gradients",
             "optimizer_variables",
-            "inputs",
             "outputs",
         ],
         save_config=smd.SaveConfig(save_interval=opt.save_interval),

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -65,7 +65,7 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
-        include_collections=["weights", "biases", "default"],
+        save_all=True,
         save_config=smd.SaveConfig(save_interval=opt.save_interval),
     )
 

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -36,6 +36,11 @@ def train(batch_size, epoch, model, hook):
     X_train /= 128.0
     X_valid /= 128.0
 
+    # save_scalar() API can be used to save arbitrary scalar values that may
+    # or may not be related to training.
+    # Ref: https://github.com/awslabs/sagemaker-debugger/blob/master/docs/api.md#common-hook-api
+    hook.save_scalar("epoch", epoch, sm_metric=True)
+
     model.fit(
         X_train,
         Y_train,
@@ -47,6 +52,8 @@ def train(batch_size, epoch, model, hook):
         # adding hook as a callback
         callbacks=[hook],
     )
+
+    hook.save_scalar("batch_size", batch_size, sm_metric=True)
 
 
 def main():

--- a/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
+++ b/examples/tensorflow2/scripts/tf_keras_fit_non_eager.py
@@ -64,6 +64,7 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
+        # Information on default collections https://github.com/awslabs/sagemaker-debugger/blob/master/docs/api.md#default-collections-saved
         include_collections=[
             "weights",
             "biases",

--- a/examples/tensorflow2/scripts/tf_keras_gradienttape.py
+++ b/examples/tensorflow2/scripts/tf_keras_gradienttape.py
@@ -81,6 +81,7 @@ def main():
     # creating hook
     hook = smd.KerasHook(
         out_dir=opt.out_dir,
+        # Information on default collections https://github.com/awslabs/sagemaker-debugger/blob/master/docs/api.md#default-collections-saved
         include_collections=["weights", "biases", "default", "gradients"],
         save_config=smd.SaveConfig(save_interval=opt.save_interval),
     )

--- a/examples/tensorflow2/scripts/tf_keras_gradienttape.py
+++ b/examples/tensorflow2/scripts/tf_keras_gradienttape.py
@@ -1,0 +1,90 @@
+"""
+This script is a ResNet training script which uses Tensorflow's Keras interface.
+It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
+Here, the hook has been created using its constructor to allow running this locally for your experimentation.
+When you want to run this script in SageMaker, it is recommended to create the hook from json file.
+Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
+"""
+
+# Standard Library
+import argparse
+
+# Third Party
+import numpy as np
+import tensorflow.compat.v2 as tf
+from tensorflow.keras.applications.resnet50 import ResNet50
+from tensorflow.keras.datasets import cifar10
+from tensorflow.keras.utils import to_categorical
+
+# First Party
+import smdebug.tensorflow as smd
+
+
+def train(batch_size, n_epochs, model, hook):
+    (x_train, y_train), _ = cifar10.load_data()
+
+    x_train = x_train.astype("float32")
+
+    mean_image = np.mean(x_train, axis=(0, 1, 2))
+    stddev_image = np.std(x_train, axis=(0, 1, 2))
+    x_train -= mean_image
+    x_train /= stddev_image
+
+    dataset = tf.data.Dataset.from_tensor_slices(
+        (tf.cast(x_train, tf.float32), tf.cast(y_train, tf.int64))
+    )
+    dataset = dataset.shuffle(1000).batch(batch_size)
+
+    optimizer = tf.keras.optimizers.Adam()
+    cce = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+    train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
+
+    num_training_samples = x_train.shape[0]
+
+    for epoch in range(n_epochs):
+        print("Epoch %d/%d" % (epoch + 1, n_epochs))
+        progBar = tf.keras.utils.Progbar(num_training_samples, stateful_metrics="accuracy")
+        for idx, (data, labels) in enumerate(dataset):
+            dataset_labels = labels
+            labels = to_categorical(labels, 10)
+            # wrap the tape so the hook can identify the gradients, parameters, loss
+            with hook.wrap_tape(tf.GradientTape()) as tape:
+                logits = model(data, training=True)  # (32,10)
+                loss_value = cce(labels, logits)
+            grads = tape.gradient(loss_value, model.trainable_variables)
+
+            optimizer.apply_gradients(zip(grads, model.trainable_variables))
+            acc = train_acc_metric(dataset_labels, logits)
+            # save metrics value
+            hook.record_tensor_value(tensor_name="accuracy", tensor_value=acc)
+            values = [("Accuracy", train_acc_metric.result())]
+            progBar.update(idx * batch_size, values=values)
+
+        train_acc_metric.reset_states()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train resnet50 cifar10")
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--epoch", type=int, default=3)
+    parser.add_argument("--model_dir", type=str, default="./model_keras_resnet")
+    parser.add_argument("--out_dir", type=str)
+    parser.add_argument("--save_interval", type=int, default=500)
+    opt = parser.parse_args()
+
+    model = ResNet50(weights=None, input_shape=(32, 32, 3), classes=10)
+
+    ##### Enabling SageMaker Debugger ###########
+    # creating hook
+    hook = smd.KerasHook(
+        out_dir=opt.out_dir,
+        include_collections=["weights", "biases", "default", "gradients"],
+        save_config=smd.SaveConfig(save_interval=opt.save_interval),
+    )
+
+    # start the training.
+    train(opt.batch_size, opt.epoch, model, hook)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tensorflow2/scripts/tf_keras_gradienttape.py
+++ b/examples/tensorflow2/scripts/tf_keras_gradienttape.py
@@ -3,7 +3,6 @@ This script is a ResNet training script which uses Tensorflow's Keras interface.
 It has been orchestrated with SageMaker Debugger hook to allow saving tensors during training.
 Here, the hook has been created using its constructor to allow running this locally for your experimentation.
 When you want to run this script in SageMaker, it is recommended to create the hook from json file.
-Please see scripts in either 'sagemaker_byoc' or 'sagemaker_official_container' folder based on your use case.
 """
 
 # Standard Library
@@ -48,6 +47,10 @@ def train(batch_size, n_epochs, model, hook):
             dataset_labels = labels
             labels = to_categorical(labels, 10)
             # wrap the tape so the hook can identify the gradients, parameters, loss
+            # wrapping the tape ensures that smdebug's wrapper around functions of
+            # the tape object - push_tape(), pop_tape(), gradient(), will setup the writers of
+            # the debugger and save tensors that are provided as input to gradient() (trainable
+            # variables and loss), output of gradient() (gradients).
             with hook.wrap_tape(tf.GradientTape()) as tape:
                 logits = model(data, training=True)  # (32,10)
                 loss_value = cce(labels, logits)

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -726,11 +726,18 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             if self._get_collections_to_save_for_step():
                 for (g, v) in zip(grads, vars):
                     layer = v.name.split(":")[0]
-                    self._save_for_tensor(
-                        tensor_name="gradients/" + layer + "Grad",
-                        tensor_value=g,
-                        check_before_write=True,
-                    )
+                    # Adding a check to make sure gradients are not None.
+                    # gradients may be None if user tries to compute gradients for
+                    # non-training variable when using model.variables instead of
+                    # model.trainable_variables in tape.gradient().
+                    # model.variables includes trainable and non-trainable
+                    # variables.
+                    if g is not None:
+                        self._save_for_tensor(
+                            tensor_name="gradients/" + layer + "Grad",
+                            tensor_value=g,
+                            check_before_write=True,
+                        )
                     self._save_for_tensor(
                         tensor_name="weights/" + v.name,
                         tensor_value=v.value(),


### PR DESCRIPTION
### Description of changes:
Adding one example script each for TF 2.x keras fit() eager , TF 2.x keras fit() non-eager, TF 2.x GradientTape.

The following table describes what tensors the examples save

|                                     | keras fit() eager | keras fit() non-eager | GradientTape |
|-------------------------------------|-------------------|-----------------------|--------------|
| loss                                | yes               | yes                   | yes          |
| metrics                             | yes               | yes                   | yes          |
| weights                             | yes               | yes                   | yes          |
| biases                              | yes               | yes                   | yes          |
| gradients                           | no                | yes                   | yes          |
| input/output to model               | no                | no                    | no           |
| input/output of intermediate layers | no                | yes                   | no           |
| optimizer variables                 | no                | yes                   | no           |
| arbitrary scalar                                    | yes                  | yes                      |  yes            |
|                                     |                   |                       |              |

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
