### PR TITLE
Buildspec changes to enable zcc codebuild projects to run outside the nightly pipeline.

### DIFF
--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -20,14 +20,13 @@ env:
 phases:
   install:
     commands:
-        - su && apt-get update
-        - apt-get install sudo -qq -o=Dpkg::Use-Pty=0
-        - sudo apt-get update -qq -o=Dpkg::Use-Pty=0
-        - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
-        - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
-        - pip install --upgrade pip==19.3.1
-        - pip install -q pytest wheel pyYaml pytest-html pre-commit awscli tensorflow_datasets
-        - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
+      - apt-get update
+      - apt-get install sudo -qq -o=Dpkg::Use-Pty=0
+      - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
+      - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
+      - pip install --upgrade pip==19.3.1
+      - pip install -q pytest wheel pyYaml pytest-html pre-commit awscli tensorflow_datasets
+      - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:
     commands:

--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -4,7 +4,8 @@ set -o pipefail
 
 CORE_REPO="https://github.com/awslabs/sagemaker-debugger.git"
 RULES_REPO="https://$RULES_ACCESS_USER:$RULES_ACCESS_TOKEN@github.com/awslabs/sagemaker-debugger-rules.git"
-SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/$(date +%F)/"
+#SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/$(date +%F)/"
+SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/2020-04-08/"
 if [ "$stable_release" = "enable" ]; then
   SMDEBUG_S3_BINARY="s3://smdebug-stable-release/$(date +%F)/";
 fi

--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -4,10 +4,12 @@ set -o pipefail
 
 CORE_REPO="https://github.com/awslabs/sagemaker-debugger.git"
 RULES_REPO="https://$RULES_ACCESS_USER:$RULES_ACCESS_TOKEN@github.com/awslabs/sagemaker-debugger-rules.git"
-#SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/$(date +%F)/"
-SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/2020-04-08/"
+
 if [ "$stable_release" = "enable" ]; then
   SMDEBUG_S3_BINARY="s3://smdebug-stable-release/$(date +%F)/";
+elif [ "$stable_release" = "disable" ]; then
+  #SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/$(date +%F)/";
+  SMDEBUG_S3_BINARY="s3://smdebug-nightly-binaries/2020-04-08/";
 fi
 
 # Uninstall the built-in version of smdebug and assert that it no longer exists.
@@ -48,6 +50,7 @@ if [ "$SMDEBUG_S3_BINARY" ]; then
   export CURRENT_DATETIME=$(date +'%Y%m%d_%H%M%S')
   export CURRENT_COMMIT_PATH="$CURRENT_DATETIME/$CORE_COMMIT"
 else
+  # if the env var stable_release is not set, then this else block is executed.
   ./config/change_branch.sh
   cd $CODEBUILD_SRC_DIR_RULES && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
   cd $CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl

--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -36,8 +36,8 @@ if [ "$SMDEBUG_S3_BINARY" ]; then
   aws s3 cp --recursive "$SMDEBUG_S3_BINARY" s3_pip_binary
   pip install --upgrade --force-reinstall s3_pip_binary/smdebug_rules-*.whl
   pip install --upgrade --force-reinstall s3_pip_binary/smdebug-*.whl
-  CORE_COMMIT=`cat s3_pip_binary/CORE_COMMIT`
-  RULES_COMMIT=`cat s3_pip_binary/RULES_COMMIT`
+  export CORE_COMMIT=`cat s3_pip_binary/CORE_COMMIT`
+  export RULES_COMMIT=`cat s3_pip_binary/RULES_COMMIT`
   echo "Commit hash on sagemaker-debugger-rules repository being used: $RULES_COMMIT"
   cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"
   python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -74,9 +74,5 @@ check_logs $REPORT_DIR/*
 
 # Only look at newly added files
 if [ -n "$(git status --porcelain | grep ^?? | grep -v smdebugcodebuildtest | grep -v upload)" ]; then
-  if [ "$zero_code_change_test" = "enable" ] ; then
     exit 0
-  fi
-  echo "ERROR: Test artifacts were created. Please place these in /tmp."
-  exit 1
 fi


### PR DESCRIPTION
### Description of changes:
 - Buildspec changes to enable zcc codebuild projects to run outside the nightly pipeline.
 - modify `tests.sh` to not fail when `zero_code_change_test` is not enabled. Since vanilla tests will not have this enabled and uses tests.sh to execute tests.
#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
