### PR TITLE
Modifying the assert to work on both vanilla and AWS PT

### DIFF
--- a/tests/pytorch/test_loss.py
+++ b/tests/pytorch/test_loss.py
@@ -78,8 +78,8 @@ def test_register_loss_functional(out_dir):
     loss_tensor = trial.tensor("nll_loss_output_0")
 
     # Capture ['nll_loss_output_0']
-    assert len(trial.tensor_names()) == 2
-    assert len(loss_coll.tensor_names) == 2
+    assert len(trial.tensor_names()) >= 1
+    assert len(loss_coll.tensor_names) >= 1
 
     # Loss should be logged for all the steps since passed `available_steps = range(n_steps)`
     assert len(trial.steps()) == n_steps


### PR DESCRIPTION
### Description of changes:
Vanilla PT will save loss only once when hook.record_tensor_value() is called.
While for AWS-PT, this test saves loss twice as described in this issue https://github.com/awslabs/sagemaker-debugger/issues/205.

The flavor of PT cannot be differentiated in the code, hence modifying the assert in the test to work with both flavors.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
