### PR TITLE
Explain cuInit Error Logs

### DIFF
--- a/tests/core/test_index_utils.py
+++ b/tests/core/test_index_utils.py
@@ -19,6 +19,9 @@ def test_tf_device_name_serialize_and_deserialize():
 
     device_name = tf.test.gpu_device_name()
     if not bool(device_name):
+        print(
+            "There is no GPU Support on this machine. Please ignore the cuInit errors generated above"
+        )
         device_name = "/device:GPU:0"
 
     serialized_device_name = serialize_tf_device(device_name)

--- a/tests/core/test_index_utils.py
+++ b/tests/core/test_index_utils.py
@@ -2,6 +2,7 @@
 
 # First Party
 from smdebug.core.index_reader import S3IndexReader
+from smdebug.core.logger import get_logger
 from smdebug.core.s3_utils import list_s3_objects
 from smdebug.core.utils import (
     deserialize_tf_device,
@@ -15,11 +16,12 @@ from smdebug.exceptions import IndexReaderException
 
 
 def test_tf_device_name_serialize_and_deserialize():
+    logger = get_logger()
     import tensorflow.compat.v1 as tf
 
     device_name = tf.test.gpu_device_name()
     if not bool(device_name):
-        print(
+        logger.warning(
             "There is no GPU Support on this machine. Please ignore the cuInit errors generated above"
         )
         device_name = "/device:GPU:0"


### PR DESCRIPTION
### Description of changes:
- `test_tf_device_name_serialize_and_deserialize` generated cuInit error logs with there is no GPU support
- GPU support is not however required for this test and hence should be ignored.
- This additional print statement tells anyone going through the logs to ignore the cuInit error

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
