### PR TITLE
Save Opt Var in TRAIN mode only

### DIFF
--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -505,7 +505,7 @@ class TensorflowBaseHook(BaseHook):
         # But in TF 2.1, only ops.executing_eagerly_outside_functions() is valid
         # since this is done for each variable at a time for keras, not checking if set already
         self.collection_manager.get(CollectionKeys.OPTIMIZER_VARIABLES).add_for_mode(
-            optimizer_variables, self.mode
+            optimizer_variables, ModeKeys.TRAIN
         )
 
     @staticmethod

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -561,7 +561,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
     def _write_optimizer_variables(self):
         optimizer_collections = self.collection_manager.get(CollectionKeys.OPTIMIZER_VARIABLES)
         collections_to_save = self._get_collections_to_save_for_step()
-        for tensor_ref in optimizer_collections.get_tensors(self.mode):
+        for tensor_ref in optimizer_collections.get_tensors(mode=ModeKeys.TRAIN):
             tensor = tensor_ref.tf_obj
             collections_to_save = self._get_collections_with_tensor(tensor.name).intersection(
                 collections_to_save


### PR DESCRIPTION
### Description of changes:
- `Bug Description`: Optimizer variables are only recorded during TRAIN mode.
However, while recording tensors, when `set_optimizer_variables` was invoked, `self.mode` inconsistently TRAIN or GLOBAL across Vanilla and AWS TF.
- This PR explicitly saves optimizer variables with `mode=ModeKeys.TRAIN`

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
