### PR TITLE
Codecov Env Variable

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -17,6 +17,8 @@ env:
     run_integration_pytest_xgboost: "disable"
     # below needs to be enabled
     zero_code_change_test: "enable"
+    # set code coverage flag
+    code_coverage_smdebug: "true"
 phases:
   install:
     commands:

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -17,26 +17,26 @@ check_logs() {
 run_for_framework() {
     if [ "$zero_code_change_test" = "enable" ] ; then
       # ignoring some test becuase they require multiple frmaeworks to be installed, these tests need to be broken down
-      python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
+      python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
       if [ "$1" = "mxnet" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
       elif [ "$1" = "pytorch" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_pytorch_integration.py
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_pytorch_multiprocessing.py
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_training_with_no_grad_updates.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_multiprocessing.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_training_with_no_grad_updates.py
       elif [ "$1" = "tensorflow" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow_integration.py
       elif [ "$1" = "tensorflow2" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow2_gradtape_integration.py
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow2_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow2_gradtape_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow2_integration.py
       fi
 
     else
       if [ "$1" = "tensorflow2" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --html=$REPORT_DIR/report_$1/eager_mode.html -v -s --self-contained-html tests/$1
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --non-eager --html=$REPORT_DIR/report_$1/non_eager_mode.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} --durations=50 --html=$REPORT_DIR/report_$1/eager_mode.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} --durations=50 --non-eager --html=$REPORT_DIR/report_$1/non_eager_mode.html -v -s --self-contained-html tests/$1
       else
-        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
       fi
     fi
 }
@@ -48,7 +48,7 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
 run_for_framework core
 

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -17,26 +17,26 @@ check_logs() {
 run_for_framework() {
     if [ "$zero_code_change_test" = "enable" ] ; then
       # ignoring some test becuase they require multiple frmaeworks to be installed, these tests need to be broken down
-      python -m pytest --cov=./ --cov-append  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
+      python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
       if [ "$1" = "mxnet" ] ; then
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_mxnet_gluon_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
       elif [ "$1" = "pytorch" ] ; then
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_pytorch_integration.py
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_pytorch_multiprocessing.py
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_training_with_no_grad_updates.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_pytorch_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_pytorch_multiprocessing.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_training_with_no_grad_updates.py
       elif [ "$1" = "tensorflow" ] ; then
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_tensorflow_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow_integration.py
       elif [ "$1" = "tensorflow2" ] ; then
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_tensorflow2_gradtape_integration.py
-        python -m pytest --cov=./ --cov-append  tests/zero_code_change/test_tensorflow2_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow2_gradtape_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append}  tests/zero_code_change/test_tensorflow2_integration.py
       fi
 
     else
       if [ "$1" = "tensorflow2" ] ; then
-        python -m pytest --cov=./ --cov-append --durations=50 --html=$REPORT_DIR/report_$1/eager_mode.html -v -s --self-contained-html tests/$1
-        python -m pytest --cov=./ --cov-append --durations=50 --non-eager --html=$REPORT_DIR/report_$1/non_eager_mode.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --html=$REPORT_DIR/report_$1/eager_mode.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --non-eager --html=$REPORT_DIR/report_$1/non_eager_mode.html -v -s --self-contained-html tests/$1
       else
-        python -m pytest --cov=./ --cov-append --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
+        python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html tests/$1
       fi
     fi
 }
@@ -48,7 +48,7 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest --cov=./ --cov-append -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest ${code_coverage_smdebug:+--cov=./} ${code_coverage_smdebug:+--cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
 run_for_framework core
 


### PR DESCRIPTION
### Description of changes:
- Introducing a new env variable `code_coverage_smdebug` to manage the code_cov flag
- We only want to obtain the code coverage metrics for PR build CI
- This also prevents the triggering the `pytest-cov` across repositories which seems to be flaky.
#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
