### PR TITLE
Add is_tf_2_2 check to test_keras_mirrored.py

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -28,7 +28,7 @@ phases:
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
-        - pip install -q pytest wheel pytest-html pre-commit awscli tensorflow_datasets
+        - pip install -q pytest wheel pytest-html pre-commit awscli tensorflow_datasets pytest-cov
 
   pre_build:
     commands:

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -28,7 +28,7 @@ phases:
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
-        - pip install -q pytest wheel pytest-html pre-commit awscli tensorflow_datasets pytest-cov
+        - pip install -q pytest wheel pytest-html pre-commit awscli tensorflow_datasets
 
   pre_build:
     commands:

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -6,12 +6,10 @@ before pushing to master.
 This was tested with TensorFlow 2.1, by running
 `python tests/tensorflow2/test_keras.py` from the main directory.
 """
-# Standard Library
-from re import search
-
 # Third Party
 import pytest
 import tensorflow.compat.v2 as tf
+from tests.tensorflow2.utils import is_tf_2_2
 from tests.tensorflow.utils import create_trial_fast_refresh
 
 # First Party
@@ -22,19 +20,6 @@ from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.exceptions import TensorUnavailableForStep
 from smdebug.tensorflow import ReductionConfig, SaveConfig
-
-
-def is_tf_2_2():
-    """
-    TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections.
-    where 'batch' is the batch number and size is the batch size.
-    But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total
-    number of tensor_names emitted by 1.
-    :return: bool
-    """
-    if search("2.2..", tf.__version__):
-        return True
-    return False
 
 
 def helper_keras_fit(

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -9,6 +9,7 @@ import pytest
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 from tensorflow.python.client import device_lib
+from tests.tensorflow2.utils import is_tf_2_2
 from tests.tensorflow.utils import create_trial_fast_refresh
 
 # First Party
@@ -157,8 +158,9 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     if include_workers == "all":
         assert len(tr.workers()) == strategy.num_replicas_in_sync
         if eager:
-            assert len(tr.tensor_names()) == (6 + 3 + 1)
-            # 6 weights, 1 loss, 3 metrics
+            assert len(tr.tensor_names()) == (6 + 1 + 2 + 5 if is_tf_2_2() else 6 + 1 + 3 + 5)
+            # 6 weights, 1 loss, 3 metrics, 5 optimizer variables for Tf 2.1
+            # 6 weights, 1 loss, 2 metrics, 5 optimizer variables for Tf 2.2
         else:
             assert len(tr.tensor_names()) == (6 + 6 + 1 + 3 + strategy.num_replicas_in_sync * 3 + 5)
     else:
@@ -222,7 +224,7 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     assert len(tr.tensor(loss_name).steps()) == 12
 
     metricnames = tr.tensor_names(collection=CollectionKeys.METRICS)
-    assert len(metricnames) == 3
+    assert len(metricnames) == (2 if is_tf_2_2() else 3)
 
 
 @pytest.mark.slow
@@ -243,8 +245,8 @@ def test_save_all(out_dir, tf_eager_mode):
     tr = create_trial_fast_refresh(out_dir)
     print(tr.tensor_names())
     if tf_eager_mode:
-        assert len(tr.tensor_names()) == 6 + 1 + 3
-        # weights, metrics, losses
+        assert len(tr.tensor_names()) == (6 + 2 + 1 + 5 if is_tf_2_2() else 6 + 3 + 1 + 5)
+        # weights, metrics, losses, optimizer variables
     else:
         assert (
             len(tr.tensor_names())
@@ -426,7 +428,7 @@ def test_clash_with_tb_callback(out_dir):
         add_callbacks=["tensorboard"],
     )
     tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.tensor_names()) == 10
+    assert len(tr.tensor_names()) == (9 if is_tf_2_2() else 10)
 
 
 def test_one_device(out_dir, tf_eager_mode):

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -158,9 +158,9 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     if include_workers == "all":
         assert len(tr.workers()) == strategy.num_replicas_in_sync
         if eager:
-            assert len(tr.tensor_names()) == (6 + 1 + 2 + 5 if is_tf_2_2() else 6 + 1 + 3 + 5)
-            # 6 weights, 1 loss, 3 metrics, 5 optimizer variables for Tf 2.1
-            # 6 weights, 1 loss, 2 metrics, 5 optimizer variables for Tf 2.2
+            assert len(tr.tensor_names()) == (6 + 1 + 2 if is_tf_2_2() else 6 + 1 + 3)
+            # 6 weights, 1 loss, 3 metrics
+            # 6 weights, 1 loss, 2 metrics
         else:
             assert len(tr.tensor_names()) == (6 + 6 + 1 + 3 + strategy.num_replicas_in_sync * 3 + 5)
     else:
@@ -245,8 +245,8 @@ def test_save_all(out_dir, tf_eager_mode):
     tr = create_trial_fast_refresh(out_dir)
     print(tr.tensor_names())
     if tf_eager_mode:
-        assert len(tr.tensor_names()) == (6 + 2 + 1 + 5 if is_tf_2_2() else 6 + 3 + 1 + 5)
-        # weights, metrics, losses, optimizer variables
+        assert len(tr.tensor_names()) == (6 + 2 + 1 if is_tf_2_2() else 6 + 3 + 1)
+        # weights, metrics, losses
     else:
         assert (
             len(tr.tensor_names())

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -1,0 +1,18 @@
+# Standard Library
+from re import search
+
+# Third Party
+import tensorflow.compat.v2 as tf
+
+
+def is_tf_2_2():
+    """
+    TF 2.0 returns ['accuracy', 'batch', 'size'] as metric collections.
+    where 'batch' is the batch number and size is the batch size.
+    But TF 2.2 returns ['accuracy', 'batch'] in eager mode, reducing the total
+    number of tensor_names emitted by 1.
+    :return: bool
+    """
+    if search("2.2..", tf.__version__):
+        return True
+    return False


### PR DESCRIPTION
### Description of changes:
- Check if the the TF version is 2.2 because the size metric is missing for Tf 2.2

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
