### PR TITLE
Skip using standalone keras Py3.7+

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ For CI, we will always run the full test suite.
 
 # Standard Library
 import shutil
+import sys
 
 # Third Party
 import pytest
@@ -65,3 +66,10 @@ def skip_if_non_eager(request):
     if request.node.get_closest_marker("skip_if_non_eager"):
         if request.config.getoption("--non-eager"):
             pytest.skip("Skipping because this test cannot be executed in non-eager mode")
+
+
+@pytest.fixture(autouse=True)
+def skip_if_py37(request):
+    if request.node.get_closest_marker("skip_if_py37"):
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
+            pytest.skip("Skipping because this test cannot be executed with Python 3.7+")

--- a/tests/tensorflow/keras/test_keras.py
+++ b/tests/tensorflow/keras/test_keras.py
@@ -213,6 +213,7 @@ def exhaustive_check(out_dir, use_tf_keras):
         assert len(tr.tensor(opt_var_name).steps(ModeKeys.EVAL)) == 0
 
 
+@pytest.mark.skip_if_py37
 @pytest.mark.slow  # 0:08 to run
 def test_keras(out_dir):
     exhaustive_check(out_dir, False)


### PR DESCRIPTION
### Description of changes:
Standalone keras doesn't support Py 3.7. https://github.com/keras-team/keras/issues/13964

Skipping the test on standalone keras in case of py 3.7+

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
