### PR TITLE
Incorrect number of tensors saved with MirroredStrategy

### DIFF
--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -290,6 +290,8 @@ class TensorflowBaseHook(BaseHook):
                     else:
                         return [self.writer_map[self.device_map[self.chief_worker]]]
                 elif self.save_all_workers or worker == self.chief_worker:
+                    # import pdb
+                    # pdb.set_trace()
                     return [self.writer_map[self.device_map[worker]]]
             elif self.writer:
                 # training on CPU when all device strings have cpu

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -290,8 +290,6 @@ class TensorflowBaseHook(BaseHook):
                     else:
                         return [self.writer_map[self.device_map[self.chief_worker]]]
                 elif self.save_all_workers or worker == self.chief_worker:
-                    # import pdb
-                    # pdb.set_trace()
                     return [self.writer_map[self.device_map[worker]]]
             elif self.writer:
                 # training on CPU when all device strings have cpu

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -66,8 +66,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             if is_tf_version_2x() and tf.executing_eagerly():
                 self.logger.info(
                     "Executing in TF2.x eager mode."
-                    "TF 2.x eager doesn't provide gradient and optimizer variable values."
-                    "SageMaker Debugger will not be saving gradients and optimizer variables in this case"
+                    "SageMaker Debugger will not be saving gradients"
                 )
             if (
                 not is_tf_version_2x()
@@ -317,13 +316,16 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
 
     def _prepare_non_layer_tensors(self):
         # for gradients, optimizer_variables
-        custom_collections, default_tf_collection = self._get_custom_and_default_collections()
-        for default_coll in default_tf_collection:
-            for tensor_ref in default_coll.get_tensors():
+        custom_collections, _ = self._get_custom_and_default_collections()
+        for coll in [
+            self.get_collection(name=CollectionKeys.OPTIMIZER_VARIABLES),
+            self.get_collection(name=CollectionKeys.GRADIENTS),
+        ]:
+            for tensor_ref in coll.get_tensors():
                 if tensor_ref.name not in self.tensor_to_collections:
-                    self.tensor_to_collections[tensor_ref.name] = {default_coll}
-                elif default_coll not in self.tensor_to_collections[tensor_ref.name]:
-                    self.tensor_to_collections[tensor_ref.name].add(default_coll)
+                    self.tensor_to_collections[tensor_ref.name] = {coll}
+                elif coll not in self.tensor_to_collections[tensor_ref.name]:
+                    self.tensor_to_collections[tensor_ref.name].add(coll)
 
                 # Add tensor to custom collections
                 for custom_coll in custom_collections:
@@ -567,6 +569,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                 collections_to_save
             )
             if len(collections_to_save):
+                self._initialize_writers(only_initialize_if_missing=True)
                 tensor = tensor_ref.tf_obj
                 self._save_for_tensor(
                     tensor_name=tensor.name, tensor_value=tensor.value(), check_before_write=False

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -571,9 +571,12 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             if len(collections_to_save):
                 self._initialize_writers(only_initialize_if_missing=True)
                 tensor = tensor_ref.tf_obj
-                self._save_for_tensor(
-                    tensor_name=tensor.name, tensor_value=tensor.value(), check_before_write=False
-                )
+                self._add_to_device_map(tensor)
+                tf_names = get_tf_names(tensor)
+                for name in tf_names:
+                    self._save_for_tensor(
+                        tensor_name=name, tensor_value=tensor.value(), check_before_write=False
+                    )
 
     def _on_any_batch_end(self, batch, mode, logs=None):
         if self._is_not_supported():

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -410,6 +410,9 @@ def test_include_regex(out_dir, tf_eager_mode, workers):
         assert len(tnames) == 4 + 3 * strategy.num_replicas_in_sync
     for tname in tnames:
         assert tr.tensor(tname).value(0) is not None
+        assert len(tr.tensor(tname).workers(0)) == (
+            1 if workers == "one" else strategy.num_replicas_in_sync
+        )
 
 
 @pytest.mark.slow
@@ -430,11 +433,14 @@ def test_include_regex_opt_var(out_dir, tf_eager_mode, workers):
     tnames = tr.tensor_names(collection="custom_optimizer_variables")
 
     if tf_eager_mode:
-        assert len(tnames) == 5 * (1 if workers == "one" else strategy.num_replicas_in_sync)
+        assert len(tnames) == 5
     else:
         assert len(tnames) == 4 + 3 * strategy.num_replicas_in_sync
     for tname in tnames:
         assert tr.tensor(tname).value(0) is not None
+        assert len(tr.tensor(tname).workers(0)) == (
+            1 if workers == "one" else strategy.num_replicas_in_sync
+        )
 
 
 @pytest.mark.skip_if_non_eager

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -269,61 +269,6 @@ def test_save_all(out_dir, tf_eager_mode, workers):
 
 
 @pytest.mark.slow
-def test_save_one_worker(out_dir, tf_eager_mode):
-    strategy = train_model(
-        out_dir,
-        include_collections=None,
-        save_all=True,
-        save_config=SaveConfig(save_steps=[5]),
-        steps=["train"],
-        include_workers="one",
-        eager=tf_eager_mode,
-    )
-    tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.workers()) == 1
-    assert len(tr.steps())
-    assert len(tr.tensor_names(collection="weights"))
-    assert len(tr.tensor(tr.tensor_names(collection="weights")[0]).workers(5)) == 1
-    assert len(tr.tensor_names(collection="biases"))
-    assert len(tr.tensor(tr.tensor_names(collection="biases")[0]).workers(5)) == 1
-
-
-@pytest.mark.slow
-def test_save_all_workers(out_dir, tf_eager_mode):
-    # Skip if no GPUS
-    if get_available_gpus() == 0:
-        return
-    strategy = train_model(
-        out_dir,
-        include_collections=None,
-        save_all=True,
-        save_config=SaveConfig(save_steps=[5]),
-        steps=["train"],
-        include_workers="all",
-        eager=tf_eager_mode,
-    )
-    tr = create_trial_fast_refresh(out_dir)
-    assert len(tr.workers()) == get_available_gpus()
-    assert len(tr.tensor_names(collection="weights"))
-    assert (
-        len(tr.tensor(tr.tensor_names(collection="weights")[0]).workers(5))
-        == strategy.num_replicas_in_sync
-    )
-
-    assert "conv2d/weights/conv2d/kernel:0" in tr.tensor_names(collection="weights")
-    assert (
-        len(tr.tensor("conv2d/weights/conv2d/kernel:0").workers(5)) == strategy.num_replicas_in_sync
-    )
-
-    assert len(tr.tensor_names(collection="biases"))
-    assert "conv2d/weights/conv2d/bias:0" in tr.tensor_names(collection="biases")
-    assert (
-        len(tr.tensor(tr.tensor_names(collection="biases")[0]).workers(5))
-        == strategy.num_replicas_in_sync
-    )
-
-
-@pytest.mark.slow
 def test_base_reductions(out_dir, tf_eager_mode):
     train_model(
         out_dir,

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -414,7 +414,7 @@ def test_include_regex(out_dir, tf_eager_mode, workers):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("workers", ["one", "all"])
-def test_include_regex_save_all(out_dir, tf_eager_mode, workers):
+def test_include_regex_opt_var(out_dir, tf_eager_mode, workers):
     include_collections = ["custom_optimizer_variables"]
     save_config = SaveConfig(save_interval=3)
     hook = KerasHook(


### PR DESCRIPTION
### Description of changes:
- Bug with `_prepare_non_layer_tensors`. The outerloop was iterating over all the collections instead of just gradients and optimizer variables and adding the wrong number of tensors into custom collections.
- With `mirroredstrategy` and a saveconfig with only optimizer_variable collections; writers are not initialized, this has been corrected with an explicit ` self._initialize_writers(only_initialize_if_missing=True)` call in `_save_optimizer_variables`
- `test_include_regex` now tests with include_workers= `one` and `all`
- New test `test_include_regex_opt_var` that attempts to save only optimizer variables with a custom collection 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
