### PR TITLE
Don't export to collections for all workers with unsupported distrib training

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -436,6 +436,12 @@ class BaseHook:
                     self.first_process = True
                     self.logger.info(f"Hook is writing from the hook with pid: {os.getpid()}\n")
                 else:
+                    if self.first_process is None:
+                        self.logger.warn(
+                            f"Unsupported Distributed Training Strategy Detected. \
+                            Sagemaker-Debugger will only write from one process. \
+                            The process with pid: {os.getpid()} will not be writing any data. \n"
+                        )
                     self.first_process = False
                     return
 
@@ -542,6 +548,11 @@ class BaseHook:
     def export_collections(self):
         num_workers = self._get_num_workers()
         if num_workers == 1 and self.first_process is False:
+            self.logger.warn(
+                f"Unsupported Distributed Training Strategy Detected. \
+                Sagemaker-Debugger will only write from one process. \
+                The process with pid: {os.getpid()} will not be writing any data. \n"
+            )
             return
         if self.save_all_workers is False:
             if self.chief_worker != self.worker:

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -437,11 +437,6 @@ class BaseHook:
                     self.logger.info(f"Hook is writing from the hook with pid: {os.getpid()}\n")
                 else:
                     self.first_process = False
-                    self.logger.warn(
-                        f"Unsupported Distributed Training Strategy Detected.\n\
-                        Sagemaker-Debugger will only write from one process.\n\
-                        The process with pid: {os.getpid()} will not be writing any data. \n"
-                    )
                     return
 
         if self.save_all_workers is False:
@@ -546,6 +541,8 @@ class BaseHook:
 
     def export_collections(self):
         num_workers = self._get_num_workers()
+        if num_workers == 1 and self.first_process is False:
+            return
         if self.save_all_workers is False:
             if self.chief_worker != self.worker:
                 return


### PR DESCRIPTION
### Description of changes:
When users make use of unsupported distributed training such as python multiprocessing, smdebug writes tensors captures by the first process. Looks like all the processes were trying to write collections.json. Fixing that in this PR.

Also, removing the warnings that were printed frequently

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
