### PR TITLE
Avoiding Basehook object pickling

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -240,6 +240,10 @@ class BaseHook:
         self.training_run = 0
         self._initialize_to_last_saved_state()
 
+    # This will avoid pickling of BaseHook object
+    def __getstate__(self):
+        return {}
+
     def _initialize_to_last_saved_state(self):
         self.state_store = StateStore()
         last_state = self.state_store.get_last_saved_state()


### PR DESCRIPTION
### Description of changes:
We were seeing crashes while saving models in pytorch. 
This was because BaseHook object has certain fields which are unpickable. In this change we are by passing the fields of Basehook object while pickling
TypeError: can't pickle _thread.RLock objects 

Code to reproduce the issue:
```
# Third Party
import torch
import torch.nn as nn
import torch.nn.functional as F
import torch.optim as optim
from torch.autograd import Variable
from torchvision import datasets, transforms

# First Party
import smdebug.pytorch as smd
from smdebug.pytorch import Hook, SaveConfig


class Net(nn.Module):
    def __init__(self):
        super(Net, self).__init__()

        self.add_module("conv1", nn.Conv2d(1, 20, 5, 1))
        self.add_module("relu0", nn.ReLU())
        self.add_module("max_pool", nn.MaxPool2d(2, stride=2))
        self.add_module("conv2", nn.Conv2d(20, 50, 5, 1))
        self.add_module("relu1", nn.ReLU())
        self.add_module("max_pool2", nn.MaxPool2d(2, stride=2))
        self.add_module("fc1", nn.Linear(4 * 4 * 50, 500))
        self.add_module("relu2", nn.ReLU())
        self.add_module("fc2", nn.Linear(500, 10))

    def forward(self, x):
        x = self.relu0(self.conv1(x))
        x = self.max_pool(x)
        x = self.relu1(self.conv2(x))
        x = self.max_pool2(x)
        x = x.view(-1, 4 * 4 * 50)
        x = self.relu2(self.fc1(x))
        x = self.fc2(x)
        return F.log_softmax(x, dim=1)

device = torch.device("cpu")
train_loader = torch.utils.data.DataLoader(
    datasets.MNIST(
        "./data",
        train=True,
        download=True,
        transform=transforms.Compose(
            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
        ),
    ),
    batch_size=64,
    shuffle=True,
    num_workers=1
)

model = Net().to(device)

optimizer = optim.SGD(model.parameters(), lr=0.00001)

hook = Hook(
    out_dir='/tmp/tensors',
    save_config=SaveConfig(save_steps=[0]),
    save_all=True,
)
hook.register_hook(model)

for epoch in range(1):
    hook.set_mode(smd.modes.TRAIN)
    model.train()
    for batch_idx, (data, target) in enumerate(train_loader):
        data, target = data.to(device), target.to(device)
        optimizer.zero_grad()
        output = model(Variable(data, requires_grad=True))
        loss = F.nll_loss(output, target)
        loss.backward()
        optimizer.step()
        if batch_idx == 3:
            break
        

print("save weights")
torch.save(model.state_dict(), 'model_weights')

print("save whole model")    
torch.save(model, 'model')
```

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
