### PR TITLE
Remove Reduction Warnings

### DIFF
--- a/smdebug/core/reductions.py
+++ b/smdebug/core/reductions.py
@@ -29,14 +29,15 @@ def get_basic_numpy_reduction(reduction_name, numpy_data):
             return getattr(np, reduction_name)(numpy_data)
     elif reduction_name in ALLOWED_NORMS:
         if reduction_name in ["l1", "l2"]:
-            ord = int(reduction_name[1])
+            order = int(reduction_name[1])
         else:
-            ord = None
+            order = None
 
-        if abs:
-            rv = np.linalg.norm(np.absolute(numpy_data), ord=ord)
-        else:
-            rv = np.linalg.norm(numpy_data, ord=ord)
+        if np.isscalar(numpy_data):
+            # np.linalg.norm expects array-like inputs
+            # but numpy_data can sometimes be a scalar value
+            numpy_data = [numpy_data]
+        rv = np.linalg.norm(numpy_data, ord=order)
         return rv
     return None
 

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -527,6 +527,8 @@ class TensorflowBaseHook(BaseHook):
 
     @staticmethod
     def _get_reduction_of_data(reduction_name, tensor_value, tensor_name, abs):
+        if hasattr(tensor_value, "numpy"):
+            tensor_value = tensor_value.numpy()
         return get_numpy_reduction(reduction_name, tensor_value, abs)
 
     def add_to_collection(self, collection_name, variable):


### PR DESCRIPTION
### Description of changes:
- Reduction values were obtained by passing values to `np.linalg.norm`. This fn however, does not support scalars and throws an error.
- The PR converts scalars to array-like objects before passing them to the fn.
- The `get_basic_numpy_reduction ` performed this check `if abs:`, which always evaluated to `True` because it clashed with the name of a python builtin.


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available
#261
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
