### PR TITLE
Refactor: Move SagemakerSimulator to test utils

### DIFF
--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -3,7 +3,6 @@ import bisect
 import json
 import os
 import re
-import shutil
 import socket
 from pathlib import Path
 from typing import Dict, List
@@ -295,84 +294,3 @@ def get_tb_worker():
 def remove_file_if_exists(file_path):
     if os.path.exists(file_path):
         os.remove(file_path)
-
-
-class SagemakerSimulator(object):
-    """
-    Creates an environment variable pointing to a JSON config file, and creates the config file.
-    Used for integration testing with zero-code-change.
-
-    If `disable=True`, then we still create the `out_dir` directory, but ignore the config file.
-    """
-
-    def __init__(
-        self,
-        json_config_path="/tmp/zcc_config.json",
-        tensorboard_dir="/tmp/tensorboard",
-        training_job_name="sm_job",
-        json_file_contents="{}",
-        cleanup=True,
-    ):
-        self.out_dir = DEFAULT_SAGEMAKER_OUTDIR
-        self.json_config_path = json_config_path
-        self.tb_json_config_path = DEFAULT_SAGEMAKER_TENSORBOARD_PATH
-        self.tensorboard_dir = tensorboard_dir
-        self.training_job_name = training_job_name
-        self.json_file_contents = json_file_contents
-        self.cleanup = cleanup
-
-    def __enter__(self):
-        if self.cleanup is True:
-            shutil.rmtree(self.out_dir, ignore_errors=True)
-        shutil.rmtree(self.json_config_path, ignore_errors=True)
-        tb_parent_dir = str(Path(self.tb_json_config_path).parent)
-        shutil.rmtree(tb_parent_dir, ignore_errors=True)
-
-        os.environ[CONFIG_FILE_PATH_ENV_STR] = self.json_config_path
-        os.environ[TENSORBOARD_CONFIG_FILE_PATH_ENV_STR] = self.tb_json_config_path
-        os.environ["TRAINING_JOB_NAME"] = self.training_job_name
-        with open(self.json_config_path, "w+") as my_file:
-            # We'll just use the defaults, but the file is expected to exist
-            my_file.write(self.json_file_contents)
-
-        os.makedirs(tb_parent_dir, exist_ok=True)
-        with open(self.tb_json_config_path, "w+") as my_file:
-            my_file.write(
-                f"""
-                {{
-                    "LocalPath": "{self.tensorboard_dir}"
-                }}
-                """
-            )
-
-        return self
-
-    def __exit__(self, *args):
-        # Throws errors when the writers try to close.
-        # shutil.rmtree(self.out_dir, ignore_errors=True)
-        if self.cleanup is True:
-            remove_file_if_exists(self.json_config_path)
-            remove_file_if_exists(self.tb_json_config_path)
-            if CONFIG_FILE_PATH_ENV_STR in os.environ:
-                del os.environ[CONFIG_FILE_PATH_ENV_STR]
-            if "TRAINING_JOB_NAME" in os.environ:
-                del os.environ["TRAINING_JOB_NAME"]
-            if TENSORBOARD_CONFIG_FILE_PATH_ENV_STR in os.environ:
-                del os.environ[TENSORBOARD_CONFIG_FILE_PATH_ENV_STR]
-
-
-class ScriptSimulator(object):
-    def __init__(self, out_dir="/tmp/test", tensorboard_dir=None):
-        self.out_dir = out_dir
-        self.tensorboard_dir = tensorboard_dir
-
-    def __enter__(self):
-        shutil.rmtree(self.out_dir, ignore_errors=True)
-        if self.tensorboard_dir:
-            shutil.rmtree(self.tensorboard_dir, ignore_errors=True)
-        return self
-
-    def __exit__(self, *args):
-        shutil.rmtree(self.out_dir, ignore_errors=True)
-        if self.tensorboard_dir:
-            shutil.rmtree(self.tensorboard_dir, ignore_errors=True)

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -3,11 +3,13 @@ import os
 import uuid
 from tempfile import TemporaryDirectory
 
+# Third Party
+from tests.utils import SagemakerSimulator, ScriptSimulator
+
 # First Party
 from smdebug.core.access_layer.file import SMDEBUG_TEMP_PATH_SUFFIX, get_temp_path
 from smdebug.core.access_layer.utils import training_has_ended
 from smdebug.core.hook_utils import verify_and_get_out_dir
-from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 from smdebug.trials import create_trial
 
 # Local

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -6,6 +6,7 @@ from multiprocessing import Manager, Process
 from os import makedirs
 
 import pytest
+from tests.utils import SagemakerSimulator, is_first_process, is_s3
 
 # First Party
 from smdebug.core.access_layer import check_dir_exists
@@ -19,7 +20,6 @@ from smdebug.core.json_config import (
     get_json_config_as_dict,
 )
 from smdebug.core.locations import IndexFileLocationUtils
-from smdebug.core.utils import SagemakerSimulator, is_first_process, is_s3
 
 
 def test_normal():

--- a/tests/pytorch/test_hook_paths.py
+++ b/tests/pytorch/test_hook_paths.py
@@ -1,9 +1,11 @@
 # Standard Library
 import os
 
+# Third Party
+from tests.utils import SagemakerSimulator, ScriptSimulator
+
 # First Party
 import smdebug.pytorch as smd
-from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 
 
 def test_tensorboard_dir_sagemaker():

--- a/tests/tensorflow/test_sagemaker.py
+++ b/tests/tensorflow/test_sagemaker.py
@@ -1,6 +1,8 @@
 # First Party
+# Third Party
+from tests.utils import SagemakerSimulator
+
 import smdebug.tensorflow as smd
-from smdebug.core.utils import SagemakerSimulator
 
 
 def test_sagemaker():

--- a/tests/tensorflow2/test_sagemaker.py
+++ b/tests/tensorflow2/test_sagemaker.py
@@ -1,6 +1,8 @@
 # First Party
+# Third Party
+from tests.utils import SagemakerSimulator
+
 import smdebug.tensorflow as smd
-from smdebug.core.utils import SagemakerSimulator
 
 
 def test_sagemaker():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -78,3 +78,20 @@ class SagemakerSimulator(object):
                 del os.environ["TRAINING_JOB_NAME"]
             if TENSORBOARD_CONFIG_FILE_PATH_ENV_STR in os.environ:
                 del os.environ[TENSORBOARD_CONFIG_FILE_PATH_ENV_STR]
+
+
+class ScriptSimulator(object):
+    def __init__(self, out_dir="/tmp/test", tensorboard_dir=None):
+        self.out_dir = out_dir
+        self.tensorboard_dir = tensorboard_dir
+
+    def __enter__(self):
+        shutil.rmtree(self.out_dir, ignore_errors=True)
+        if self.tensorboard_dir:
+            shutil.rmtree(self.tensorboard_dir, ignore_errors=True)
+        return self
+
+    def __exit__(self, *args):
+        shutil.rmtree(self.out_dir, ignore_errors=True)
+        if self.tensorboard_dir:
+            shutil.rmtree(self.tensorboard_dir, ignore_errors=True)

--- a/tests/zero_code_change/test_mxnet_gluon_integration.py
+++ b/tests/zero_code_change/test_mxnet_gluon_integration.py
@@ -7,9 +7,7 @@ import mxnet as mx
 import numpy as np
 from mxnet import autograd, gluon
 from mxnet.gluon import nn
-
-# First Party
-from smdebug.core.utils import SagemakerSimulator
+from tests.utils import SagemakerSimulator
 
 
 def parse_args():

--- a/tests/zero_code_change/test_pytorch_integration.py
+++ b/tests/zero_code_change/test_pytorch_integration.py
@@ -15,11 +15,11 @@ import pytest
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from tests.utils import SagemakerSimulator, ScriptSimulator
 from tests.zero_code_change.pt_utils import Net, get_dataloaders
 
 # First Party
 import smdebug.pytorch as smd
-from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 
 
 @pytest.mark.parametrize("script_mode", [False])

--- a/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
@@ -13,10 +13,10 @@ import argparse
 import pytest
 import tensorflow.compat.v2 as tf
 from tests.tensorflow2.utils import is_tf_2_2
+from tests.utils import SagemakerSimulator
 
 # First Party
 import smdebug.tensorflow as smd
-from smdebug.core.utils import SagemakerSimulator
 
 
 def get_keras_data():

--- a/tests/zero_code_change/test_tensorflow_integration.py
+++ b/tests/zero_code_change/test_tensorflow_integration.py
@@ -23,6 +23,7 @@ import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
 from tests.tensorflow.hooks.test_mirrored_strategy import test_basic
 from tests.tensorflow.keras.test_keras_mirrored import test_tf_keras
+from tests.utils import SagemakerSimulator
 from tests.zero_code_change.tf_utils import (
     get_data,
     get_estimator,
@@ -34,7 +35,6 @@ from tests.zero_code_change.tf_utils import (
 
 # First Party
 import smdebug.tensorflow as smd
-from smdebug.core.utils import SagemakerSimulator
 
 
 @pytest.mark.parametrize("script_mode", [False])


### PR DESCRIPTION
### Description of changes:
- The SagemakerSimulator class is only used in tests, but was defined in the `smdebug/core` file
- The PR moves it over to `tests/utils`.


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
