### PR TITLE
Moved end of training log from info to debug

### DIFF
--- a/smdebug/core/access_layer/utils.py
+++ b/smdebug/core/access_layer/utils.py
@@ -21,7 +21,7 @@ logger = get_logger()
 def training_has_ended(trial_prefix):
     # Emit the end of training file only if the job is not running under SageMaker.
     if is_sagemaker_job():
-        logger.info(
+        logger.debug(
             f"The end of training job file will not be written for jobs running under SageMaker."
         )
         return


### PR DESCRIPTION
https://github.com/awslabs/sagemaker-debugger/issues/280


### Description of changes:


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
