### PR TITLE
Adding a test to check that PT model is saved without issues

### DIFF
--- a/tests/pytorch/test_simple_write.py
+++ b/tests/pytorch/test_simple_write.py
@@ -266,6 +266,12 @@ def saveall_test_helper(hook=None):
     else:
         addendum = "jsonloading"
     hook._cleanup()
+
+    # smdebug hook should not be pickled. Check if model is saved without issues.
+    # The following two lines will error out if there is an attempt to pickle the hook.
+    torch.save(model.state_dict(), "/tmp/test_output/test_hook_saveall/model_weights")
+    torch.save(model, "/tmp/test_output/test_hook_saveall/model")
+
     delete_local_trials(["/tmp/test_output/test_hook_saveall/" + addendum])
 
 


### PR DESCRIPTION
### Description of changes:
This PR adds a model saving to a pytorch test to ensure there are no issues pickling.
This is a follow-up to https://github.com/awslabs/sagemaker-debugger/pull/266

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
