### PR TITLE
Check if Version is TF 2.2 or greater in tests

### DIFF
--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -1,8 +1,7 @@
 # Standard Library
-from re import search
-
 # Third Party
 import tensorflow.compat.v2 as tf
+from packaging import version
 
 
 def is_tf_2_2():
@@ -13,6 +12,6 @@ def is_tf_2_2():
     number of tensor_names emitted by 1.
     :return: bool
     """
-    if search("2.2..", tf.__version__):
+    if version.parse(tf.__version__) >= version.parse("2.2.0"):
         return True
     return False


### PR DESCRIPTION
### Description of changes:
- TF 2.0 used to return ['accuracy', 'batch', 'size'] as as metric collections.
    where 'batch' is the batch number and size is the batch size.
- But TF 2.2 and greater  returns ['accuracy', 'batch'] in eager mode, reducing the total
    number of tensor_names emitted by 1.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
