### PR TITLE
Disable TB in ZCC for AWS TF 2.3.0

### DIFF
--- a/tests/zero_code_change/test_tensorflow2_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_integration.py
@@ -55,10 +55,10 @@ def helper_test_keras_v2(script_mode: bool = False, eager_mode: bool = True):
         # v1 training APIs are currently not supported
         # in ZCC mode with smdebug 0.9 and AWS TF 2.3.0
         tf.compat.v1.disable_eager_execution()
+
+    # Performance regression in the _make_histogram fn
     enable_tb = False if tf.__version__ == "2.0.2" else True
-    if is_tf_2_3():
-        # Performance regression in the _make_histogram fn
-        enable_tb = False
+    enable_tb = False if is_tf_2_3() else enable_tb
     with SagemakerSimulator(enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()
         (x_train, y_train), (x_test, y_test) = get_keras_data()
@@ -121,10 +121,11 @@ def helper_test_keras_v2_json_config(
         # v1 training APIs are currently not supported
         # in ZCC mode with smdebug 0.9 and AWS TF 2.3.0
         tf.compat.v1.disable_eager_execution()
+
+    # Performance regression in the _make_histogram fn
     enable_tb = False if tf.__version__ == "2.0.2" else True
-    if is_tf_2_3():
-        # Performance regression in the _make_histogram fn
-        enable_tb = False
+    enable_tb = False if is_tf_2_3() else enable_tb
+
     with SagemakerSimulator(json_file_contents=json_file_contents, enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()
         (x_train, y_train), (x_test, y_test) = get_keras_data()

--- a/tests/zero_code_change/test_tensorflow2_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_integration.py
@@ -57,8 +57,7 @@ def helper_test_keras_v2(script_mode: bool = False, eager_mode: bool = True):
         tf.compat.v1.disable_eager_execution()
 
     # Performance regression in the _make_histogram fn
-    enable_tb = False if tf.__version__ == "2.0.2" else True
-    enable_tb = False if is_tf_2_3() else enable_tb
+    enable_tb = False if tf.__version__ == "2.0.2" or is_tf_2_3() else True
     with SagemakerSimulator(enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()
         (x_train, y_train), (x_test, y_test) = get_keras_data()
@@ -123,8 +122,7 @@ def helper_test_keras_v2_json_config(
         tf.compat.v1.disable_eager_execution()
 
     # Performance regression in the _make_histogram fn
-    enable_tb = False if tf.__version__ == "2.0.2" else True
-    enable_tb = False if is_tf_2_3() else enable_tb
+    enable_tb = False if tf.__version__ == "2.0.2" or is_tf_2_3() else True
 
     with SagemakerSimulator(json_file_contents=json_file_contents, enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()

--- a/tests/zero_code_change/test_tensorflow2_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_integration.py
@@ -56,6 +56,9 @@ def helper_test_keras_v2(script_mode: bool = False, eager_mode: bool = True):
         # in ZCC mode with smdebug 0.9 and AWS TF 2.3.0
         tf.compat.v1.disable_eager_execution()
     enable_tb = False if tf.__version__ == "2.0.2" else True
+    if is_tf_2_3():
+        # Performance regression in the _make_histogram fn
+        enable_tb = False
     with SagemakerSimulator(enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()
         (x_train, y_train), (x_test, y_test) = get_keras_data()
@@ -119,6 +122,9 @@ def helper_test_keras_v2_json_config(
         # in ZCC mode with smdebug 0.9 and AWS TF 2.3.0
         tf.compat.v1.disable_eager_execution()
     enable_tb = False if tf.__version__ == "2.0.2" else True
+    if is_tf_2_3():
+        # Performance regression in the _make_histogram fn
+        enable_tb = False
     with SagemakerSimulator(json_file_contents=json_file_contents, enable_tb=enable_tb) as sim:
         model = get_keras_model_v2()
         (x_train, y_train), (x_test, y_test) = get_keras_data()


### PR DESCRIPTION
### Description of changes:
- Performance regression as seen in TF 2.0.2 with `_make_histogram` fn is seen again.
- Disabling TB testing in the ZCC tests for AWS TF 2.3.0.

Link to the previous sim: https://sim.amazon.com/issues/P36665931

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
