### PR TITLE
Adding pagination in list_training_jobs

### DIFF
--- a/smdebug/rules/action/stop_training_action.py
+++ b/smdebug/rules/action/stop_training_action.py
@@ -20,7 +20,7 @@ class StopTrainingAction:
         self._rule_name = rule_name
         self._found_jobs = self._get_sm_tj_jobs_with_prefix()
 
-    def _get_sm_tj_jobs_with_prefix(self, status=["InProgress"]):
+    def _get_sm_tj_jobs_with_prefix(self):
         res = {}
         found_job_dict = {}
         next_token = None
@@ -61,10 +61,10 @@ class StopTrainingAction:
                 self._logger.info(
                     f"Caught exception while getting list_training_job exception is: \n {e}. Attempt:{i}"
                 )
-            if "NextToken" not in jobs:
+            if "NextToken" not in res:
                 break
             else:
-                next_token = jobs["NextToken"]
+                next_token = res["NextToken"]
                 res = {}
                 jobs = {}
                 i += 1

--- a/smdebug/rules/action/stop_training_action.py
+++ b/smdebug/rules/action/stop_training_action.py
@@ -20,31 +20,56 @@ class StopTrainingAction:
         self._rule_name = rule_name
         self._found_jobs = self._get_sm_tj_jobs_with_prefix()
 
-    def _get_sm_tj_jobs_with_prefix(self):
-        found_jobs = []
-        try:
-            jobs = self._sm_client.list_training_jobs()
-            if "TrainingJobSummaries" in jobs:
-                jobs = jobs["TrainingJobSummaries"]
+    def _get_sm_tj_jobs_with_prefix(self, status=["InProgress"]):
+        res = {}
+        found_job_dict = {}
+        next_token = None
+        name = self._training_job_prefix
+        i = 0
+        while i < 50:
+            try:
+                if next_token is None:
+                    res = self._sm_client.list_training_jobs(
+                        NameContains=name,
+                        SortBy="CreationTime",
+                        SortOrder="Descending",
+                        StatusEquals="InProgress",
+                    )
+                else:
+                    res = self._sm_client.list_training_jobs(
+                        NextToken=next_token,
+                        NameContains=name,
+                        SortBy="CreationTime",
+                        SortOrder="Descending",
+                        StatusEquals="InProgress",
+                    )
+                if "TrainingJobSummaries" in res:
+                    jobs = res["TrainingJobSummaries"]
+                else:
+                    self._logger.info(
+                        f"No TrainingJob summaries found: list_training_jobs output is : {res}"
+                    )
+                    return
+                for job in jobs:
+                    tj_status = job["TrainingJobStatus"]
+                    tj_name = job["TrainingJobName"]
+                    self._logger.info(f"TrainingJob name: {tj_name} , status:{tj_status}")
+                    if tj_name is not None and tj_name.startswith(name):
+                        found_job_dict[tj_name] = 1
+                self._logger.info(f"found_training job {found_job_dict.keys()}")
+            except Exception as e:
+                self._logger.info(
+                    f"Caught exception while getting list_training_job exception is: \n {e}. Attempt:{i}"
+                )
+            if "NextToken" not in jobs:
+                break
             else:
-                self._logger.info(
-                    f"No TrainingJob summaries found: list_training_jobs output is : {jobs}"
-                )
-                return
-            for job in jobs:
-                self._logger.info(
-                    f"TrainingJob name: {job['TrainingJobName']} , status:{job['TrainingJobStatus']}"
-                )
-                if job["TrainingJobName"] is not None and job["TrainingJobName"].startswith(
-                    self._training_job_prefix
-                ):
-                    found_jobs.append(job["TrainingJobName"])
-            self._logger.info(f"found_training job {found_jobs}")
-        except Exception as e:
-            self._logger.info(
-                f"Caught exception while getting list_training_job exception is: \n {e}"
-            )
-        return found_jobs
+                next_token = jobs["NextToken"]
+                res = {}
+                jobs = {}
+                i += 1
+
+        return found_job_dict.keys()
 
     def _stop_training_job(self):
         if len(self._found_jobs) != 1:


### PR DESCRIPTION
### Description of changes:
Adding pagination to list_training job api for StopTrainingAction. This action list the training jobs to find a training job which matches the prefix and then takes action on that training job. This PR makes sure that list looks at result for more than one page to find the unique training job. We have put 50 pages as default and we expect that the trainining job would be found in first 50 pages. 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
