### PR TITLE
Add ability to only save shapes of tensors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -96,6 +96,7 @@ include_workers
 include_regex
 reductions
 save_raw_tensor
+save_shape
 save_interval
 save_steps
 start_step

--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -760,7 +760,7 @@ class BaseHook:
             if self.dry_run is False and reduction_config.save_shape is True:
                 numpy_tensor_value = self._make_numpy_array(tensor_value)
                 this_size, this_shape = size_and_shape(numpy_tensor_value)
-                if tensor_ref is not None:
+                if tensor_ref is not None and tensor_ref.tf_obj is not None:
                     original_name = tensor_ref.tf_obj.name
                 else:
                     original_name = None

--- a/smdebug/core/index_reader.py
+++ b/smdebug/core/index_reader.py
@@ -241,8 +241,9 @@ class IndexReader(ABC):
         else:
             event_file_name = None
 
-        tensor_payload = index_dict["tensor_payload"]
         to_update_index_dict = []
+
+        tensor_payload = index_dict.get("tensor_payload", [])
         for tensor in tensor_payload:
             tensor_name = tensor["tensorname"]
             start_idx = tensor["start_idx"]
@@ -252,7 +253,7 @@ class IndexReader(ABC):
             )
             to_update_index_dict.append((tensor_name, step, tensor_location))
 
-        shape_payload = index_dict["shape_payload"]
+        shape_payload = index_dict.get("shape_payload", [])
         for tensor in shape_payload:
             tensor_name = tensor["tensorname"]
             original_name = tensor["originalname"]

--- a/smdebug/core/index_reader.py
+++ b/smdebug/core/index_reader.py
@@ -248,7 +248,7 @@ class IndexReader(ABC):
 
         to_update_index_dict = []
 
-        if len(index_dict["tensor_payload"]):
+        if "tensor_payload" in index_dict and len(index_dict["tensor_payload"]):
             event_file_name = os.path.join(path, index_meta["event_file_name"])
             for tensor in index_dict["tensor_payload"]:
                 tensor_name = tensor["tensorname"]
@@ -259,7 +259,7 @@ class IndexReader(ABC):
                 )
                 to_update_index_dict.append((tensor_name, step, tensor_location))
 
-        if len(index_dict["shape_payload"]):
+        if "shape_payload" in index_dict and len(index_dict["shape_payload"]):
             for tensor in index_dict["shape_payload"]:
                 tensor_name = tensor["tensorname"]
                 original_name = tensor["originalname"]

--- a/smdebug/core/index_reader.py
+++ b/smdebug/core/index_reader.py
@@ -16,7 +16,7 @@ from smdebug.core.config_constants import (
     MISSING_EVENT_FILE_RETRY_LIMIT,
     MISSING_EVENT_FILE_RETRY_LIMIT_KEY,
 )
-from smdebug.core.locations import IndexFileLocationUtils, TensorLocation
+from smdebug.core.locations import IndexFileLocationUtils, TensorLocation, TensorShape
 from smdebug.core.logger import get_logger
 from smdebug.core.modes import ModeKeys
 from smdebug.core.s3_utils import list_s3_objects
@@ -203,8 +203,10 @@ class IndexReader(ABC):
             raise IndexReaderException("meta section is not present")
         if len(index_dict["meta"]) == 0:
             raise IndexReaderException("meta section is empty")
-        if "tensor_payload" not in index_dict:
-            raise IndexReaderException("tensor_payload section is not present")
+        if "tensor_payload" not in index_dict and "shape_payload" not in index_dict:
+            raise IndexReaderException(
+                "neither tensor_payload nor shape_payload sections are present"
+            )
 
     def _update_tensors_from_json(
         self, index_tensors_dict, step, response: bytes, path, worker
@@ -233,28 +235,44 @@ class IndexReader(ABC):
         mode = index_meta["mode"]
         mode = ModeKeys[mode.strip()]
         mode_step = index_meta["mode_step"]
-        event_file_name = os.path.join(path, index_meta["event_file_name"])
-        tensors = index_dict["tensor_payload"]
-        for tensor in tensors:
+
+        if "event_file_name" in index_meta:
+            event_file_name = os.path.join(path, index_meta["event_file_name"])
+        else:
+            event_file_name = None
+
+        tensor_payload = index_dict["tensor_payload"]
+        to_update_index_dict = []
+        for tensor in tensor_payload:
             tensor_name = tensor["tensorname"]
             start_idx = tensor["start_idx"]
             length = tensor["length"]
             tensor_location = TensorLocation(
                 tensor_name, mode, mode_step, event_file_name, start_idx, length, worker
             )
+            to_update_index_dict.append((tensor_name, step, tensor_location))
+
+        shape_payload = index_dict["shape_payload"]
+        for tensor in shape_payload:
+            tensor_name = tensor["tensorname"]
+            original_name = tensor["originalname"]
+            shape = tensor["shape"]
+            ts = TensorShape(tensor_name, mode, mode_step, shape, original_name)
+            to_update_index_dict.append((tensor_name, step, ts))
+
+        for tu in to_update_index_dict:
+            tensor_name, step, obj = tu
+            if isinstance(obj, TensorLocation):
+                obj_dict = {"tensor_location": obj}
+            elif isinstance(obj, TensorShape):
+                obj_dict = {"tensor_shape": obj}
             if tensor_name in index_tensors_dict:
                 if step in index_tensors_dict[tensor_name]:
-                    index_tensors_dict[tensor_name][step].update(
-                        {worker: {"tensor_location": tensor_location}}
-                    )
+                    index_tensors_dict[tensor_name][step].update({worker: obj_dict})
                 else:
-                    index_tensors_dict[tensor_name].update(
-                        {step: {worker: {"tensor_location": tensor_location}}}
-                    )
+                    index_tensors_dict[tensor_name].update({step: {worker: obj_dict}})
             else:
-                index_tensors_dict[tensor_name] = {
-                    step: {worker: {"tensor_location": tensor_location}}
-                }
+                index_tensors_dict[tensor_name] = {step: {worker: obj_dict}}
         return index_tensors_dict
 
 

--- a/smdebug/core/index_reader.py
+++ b/smdebug/core/index_reader.py
@@ -248,7 +248,7 @@ class IndexReader(ABC):
 
         to_update_index_dict = []
 
-        if "tensor_payload" in index_dict:
+        if len(index_dict["tensor_payload"]):
             event_file_name = os.path.join(path, index_meta["event_file_name"])
             for tensor in index_dict["tensor_payload"]:
                 tensor_name = tensor["tensorname"]
@@ -259,7 +259,7 @@ class IndexReader(ABC):
                 )
                 to_update_index_dict.append((tensor_name, step, tensor_location))
 
-        if "shape_payload" in index_dict:
+        if len(index_dict["shape_payload"]):
             for tensor in index_dict["shape_payload"]:
                 tensor_name = tensor["tensorname"]
                 original_name = tensor["originalname"]

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -23,6 +23,9 @@ class TensorLocation:
     def to_dict(self):
         return {"tensorname": self.tensorname, "start_idx": self.start_idx, "length": self.length}
 
+    def get_mode(self):
+        return str(self.mode).split(".")[-1]
+
 
 class TensorShape:
     def __init__(self, name, mode, mode_step, shape, original_name=None):

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -24,6 +24,20 @@ class TensorLocation:
         return {"tensorname": self.tensorname, "start_idx": self.start_idx, "length": self.length}
 
 
+class TensorShape:
+    def __init__(self, name, mode, mode_step, shape, original_name=None):
+        if original_name is None:
+            original_name = name
+        self.name = name
+        self.original_name = original_name
+        self.mode = mode
+        self.mode_step = mode_step
+        self.shape = tuple(shape)
+
+    def to_dict(self):
+        return {"tensorname": self.name, "originalname": self.original_name, "shape": self.shape}
+
+
 STEP_NUMBER_FORMATTING_LENGTH = "012"
 
 
@@ -87,28 +101,6 @@ class TensorFileLocation(EventFileLocation):
     def get_step_dir_path(cls, trial_dir, step_num):
         step_num = int(step_num)
         return os.path.join(cls.get_dir(trial_dir), format(step_num, STEP_NUMBER_FORMATTING_LENGTH))
-
-
-class ShapeFileLocation(TensorFileLocation):
-    def __init__(self, step_num, worker_name):
-        super().__init__(step_num, worker_name)
-
-    def get_filename(self):
-        step_num_str = self.get_step_num_str()
-        return f"{step_num_str}_{self.worker_name}_shapes.json"
-
-    @classmethod
-    def load_filename(cls, s, print_error=True):
-        name = os.path.basename(s)
-        m = re.search("(.*)_(.*)_shapes.json$", name)
-        if m:
-            step_num = int(m.group(1))
-            worker_name = m.group(2)
-            return cls(step_num=step_num, worker_name=worker_name)
-        else:
-            if print_error:
-                logger.error("Failed to load shape file location: ", s)
-            return None
 
 
 class TensorboardFileLocation(EventFileLocation):

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -89,6 +89,28 @@ class TensorFileLocation(EventFileLocation):
         return os.path.join(cls.get_dir(trial_dir), format(step_num, STEP_NUMBER_FORMATTING_LENGTH))
 
 
+class ShapeFileLocation(TensorFileLocation):
+    def __init__(self, step_num, worker_name):
+        super().__init__(step_num, worker_name)
+
+    def get_filename(self):
+        step_num_str = self.get_step_num_str()
+        return f"{step_num_str}_{self.worker_name}_shapes.json"
+
+    @classmethod
+    def load_filename(cls, s, print_error=True):
+        name = os.path.basename(s)
+        m = re.search("(.*)_(.*)_shapes.json$", name)
+        if m:
+            step_num = int(m.group(1))
+            worker_name = m.group(2)
+            return cls(step_num=step_num, worker_name=worker_name)
+        else:
+            if print_error:
+                logger.error("Failed to load shape file location: ", s)
+            return None
+
+
 class TensorboardFileLocation(EventFileLocation):
     def __init__(self, step_num, worker_name, mode=None):
         super().__init__(step_num, worker_name)

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -40,6 +40,9 @@ class TensorShape:
     def to_dict(self):
         return {"tensorname": self.name, "originalname": self.original_name, "shape": self.shape}
 
+    def get_mode(self):
+        return str(self.mode).split(".")[-1]
+
 
 STEP_NUMBER_FORMATTING_LENGTH = "012"
 

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -23,9 +23,6 @@ class TensorLocation:
     def to_dict(self):
         return {"tensorname": self.tensorname, "start_idx": self.start_idx, "length": self.length}
 
-    def get_mode(self):
-        return str(self.mode).split(".")[-1]
-
 
 class TensorShape:
     def __init__(self, name, mode, mode_step, shape, original_name=None):
@@ -39,9 +36,6 @@ class TensorShape:
 
     def to_dict(self):
         return {"tensorname": self.name, "originalname": self.original_name, "shape": self.shape}
-
-    def get_mode(self):
-        return str(self.mode).split(".")[-1]
 
 
 STEP_NUMBER_FORMATTING_LENGTH = "012"

--- a/smdebug/core/reduction_config.py
+++ b/smdebug/core/reduction_config.py
@@ -1,6 +1,8 @@
 # Standard Library
 import json
 from typing import Any, Dict
+from smdebug.core.logger import get_logger
+logger = get_logger()
 
 # First Party
 from smdebug.core.utils import split
@@ -8,7 +10,7 @@ from smdebug.core.utils import split
 ALLOWED_REDUCTIONS = ["min", "max", "mean", "std", "variance", "sum", "prod"]
 ALLOWED_NORMS = ["l1", "l2"]
 REDUCTION_CONFIG_VERSION_NUM = "v0"
-ALLOWED_PARAMS = ["reductions", "abs_reductions", "norms", "abs_norms", "save_raw_tensor"]
+ALLOWED_PARAMS = ["reductions", "abs_reductions", "norms", "abs_norms", "save_raw_tensor", "save_shape"]
 
 
 class ReductionConfig:
@@ -49,12 +51,14 @@ class ReductionConfig:
         norms=None,
         abs_norms=None,
         save_raw_tensor=False,
+        save_shape=False,
     ):
         self.reductions = reductions if reductions is not None else []
         self.abs_reductions = abs_reductions if abs_reductions is not None else []
         self.norms = norms if norms is not None else []
         self.abs_norms = abs_norms if abs_norms is not None else []
         self.save_raw_tensor = save_raw_tensor
+        self.save_shape = save_shape
         ## DO NOT REMOVE, if you add anything here, please make sure that _check & from_json is updated accordingly
         self._check()
 
@@ -75,6 +79,9 @@ class ReductionConfig:
             raise ValueError("abs_norms can only be one of " + ",".join(ALLOWED_NORMS))
         if not isinstance(self.save_raw_tensor, bool):
             raise ValueError(f"save_raw_tensor={self.save_raw_tensor} must be a boolean")
+        if not isinstance(self.save_shape, bool):
+            raise ValueError(f"save_shape={self.save_shape} must be a boolean")
+
 
     @classmethod
     def from_dict(cls, params: Dict[str, Any]) -> "ReductionConfig":
@@ -83,7 +90,7 @@ class ReductionConfig:
             return None
         if not isinstance(params, dict):
             raise ValueError(f"params={params} must be dict")
-
+        save_shape = params.get("save_shape", False)
         save_raw_tensor = params.get("save_raw_tensor", False)
         # Parse comma-separated string into array
         all_reductions = split(params.get("reductions", ""))
@@ -108,6 +115,7 @@ class ReductionConfig:
             norms=norms,
             abs_norms=abs_norms,
             save_raw_tensor=save_raw_tensor,
+            save_shape=save_shape
         )
 
     @classmethod
@@ -116,7 +124,6 @@ class ReductionConfig:
         return cls.from_dict(d)
 
     def to_json_dict(self) -> Dict[str, Any]:
-        save_raw_tensor = self.save_raw_tensor
         # Convert reductions from various arrays into single comma-separated string
         all_reductions = []
         for red in self.reductions:
@@ -129,7 +136,7 @@ class ReductionConfig:
             all_reductions.append(f"abs_{red}_norm")
         all_reductions_str = ",".join(all_reductions)
         # Return the dict
-        return {"save_raw_tensor": save_raw_tensor, "reductions": all_reductions_str}
+        return {"save_raw_tensor": self.save_raw_tensor, "reductions": all_reductions_str, "save_shape": self.save_shape}
 
     def to_json(self) -> str:
         return json.dumps(self.to_json_dict())
@@ -144,10 +151,11 @@ class ReductionConfig:
             and self.norms == other.norms
             and self.abs_norms == other.abs_norms
             and self.save_raw_tensor == other.save_raw_tensor
+            and self.save_shape == other.save_shape
         )
 
     def __repr__(self):
         return (
             f"<class ReductionConfig: reductions={self.reductions}, "
-            f"abs_reductions={self.abs_reductions}, norms={self.norms}, abs_norms={self.abs_norms}>"
+            f"abs_reductions={self.abs_reductions}, norms={self.norms}, abs_norms={self.abs_norms}>, save_shape={self.save_shape}, save_raw_tensor={self.save_raw_tensor}"
         )

--- a/smdebug/core/reduction_config.py
+++ b/smdebug/core/reduction_config.py
@@ -1,16 +1,25 @@
 # Standard Library
 import json
 from typing import Any, Dict
-from smdebug.core.logger import get_logger
-logger = get_logger()
 
 # First Party
+from smdebug.core.logger import get_logger
 from smdebug.core.utils import split
+
+logger = get_logger()
+
 
 ALLOWED_REDUCTIONS = ["min", "max", "mean", "std", "variance", "sum", "prod"]
 ALLOWED_NORMS = ["l1", "l2"]
 REDUCTION_CONFIG_VERSION_NUM = "v0"
-ALLOWED_PARAMS = ["reductions", "abs_reductions", "norms", "abs_norms", "save_raw_tensor", "save_shape"]
+ALLOWED_PARAMS = [
+    "reductions",
+    "abs_reductions",
+    "norms",
+    "abs_norms",
+    "save_raw_tensor",
+    "save_shape",
+]
 
 
 class ReductionConfig:
@@ -82,7 +91,6 @@ class ReductionConfig:
         if not isinstance(self.save_shape, bool):
             raise ValueError(f"save_shape={self.save_shape} must be a boolean")
 
-
     @classmethod
     def from_dict(cls, params: Dict[str, Any]) -> "ReductionConfig":
         """Parses a flattened dict with two keys: `save_raw_tensor` and `reductions`."""
@@ -115,7 +123,7 @@ class ReductionConfig:
             norms=norms,
             abs_norms=abs_norms,
             save_raw_tensor=save_raw_tensor,
-            save_shape=save_shape
+            save_shape=save_shape,
         )
 
     @classmethod
@@ -136,7 +144,11 @@ class ReductionConfig:
             all_reductions.append(f"abs_{red}_norm")
         all_reductions_str = ",".join(all_reductions)
         # Return the dict
-        return {"save_raw_tensor": self.save_raw_tensor, "reductions": all_reductions_str, "save_shape": self.save_shape}
+        return {
+            "save_raw_tensor": self.save_raw_tensor,
+            "reductions": all_reductions_str,
+            "save_shape": self.save_shape,
+        }
 
     def to_json(self) -> str:
         return json.dumps(self.to_json_dict())

--- a/smdebug/core/tensor.py
+++ b/smdebug/core/tensor.py
@@ -266,6 +266,7 @@ class Tensor:
     def value(self, step_num, mode=ModeKeys.GLOBAL, worker=None):
         # step refreshes
         s = self._step(step_num=step_num, mode=mode, worker=worker)
+        print(s, s.value)
         if s.value is not None:
             return s.value
         elif s.location is not None:

--- a/smdebug/core/tensor.py
+++ b/smdebug/core/tensor.py
@@ -266,7 +266,6 @@ class Tensor:
     def value(self, step_num, mode=ModeKeys.GLOBAL, worker=None):
         # step refreshes
         s = self._step(step_num=step_num, mode=mode, worker=worker)
-        print(s, s.value)
         if s.value is not None:
             return s.value
         elif s.location is not None:

--- a/smdebug/core/tensor.py
+++ b/smdebug/core/tensor.py
@@ -10,6 +10,7 @@ import numpy as np
 from smdebug.exceptions import (
     InvalidWorker,
     NoMoreData,
+    ShapeUnavailableForStep,
     StepNotYetAvailable,
     StepUnavailable,
     TensorUnavailableForStep,
@@ -62,6 +63,16 @@ class ModeSteps:
         s = self._steps[step_num][worker]
         s.location = location
 
+    def set_step_shape(self, step_num, worker, shape):
+        step = Step(step_num, shape=shape)
+        if step_num not in self._steps:
+            self._steps[step_num] = {worker: step}
+        elif worker not in self._steps[step_num]:
+            self._steps[step_num].update({worker: step})
+
+        s = self._steps[step_num][worker]
+        s.shape = shape
+
     def set_step_reduction_value(self, step_num, worker, red_name, abs, red_value):
         if step_num not in self._steps:
             s = Step(step_num)
@@ -88,10 +99,11 @@ class ModeSteps:
 class Step:
     """Contains the step number, value, location, and reduction values/locations."""
 
-    def __init__(self, step_num, value=None, location=None):
+    def __init__(self, step_num, value=None, location=None, shape=None):
         self.step_num = step_num
         self.value = value
         self.location = location
+        self.shape = shape
 
         # mapping from (red_name, abs) to value
         self._reduction_values = {}
@@ -126,6 +138,9 @@ class Tensor:
     def __init__(self, name, trial, cache):
         self._mode_steps = {}
         self.name = name
+        # SMdebug modifies some names of tensors to be more descriptive
+        # In such cases we save here the original name
+        self.original_name = None
         self.trial = trial
         self.cache = cache
 
@@ -264,6 +279,16 @@ class Tensor:
             has_reductions = has_reduction_locations or has_reduction_values
             raise TensorUnavailableForStep(self.name, step_num, mode, has_reductions)
 
+    def shape(self, step_num, mode=ModeKeys.GLOBAL, worker=None):
+        s = self._step(step_num=step_num, mode=mode, worker=worker)
+        if s.shape is not None:
+            return s.shape
+        try:
+            value = self.value(step_num, mode, worker)
+            return value.shape
+        except TensorUnavailableForStep:
+            raise ShapeUnavailableForStep(self.name, step_num, mode)
+
     def reduction_values(self, step_num, mode=ModeKeys.GLOBAL, worker=None):
         s = self._step(step_num=step_num, mode=mode, worker=worker)
         if s is not None:
@@ -334,9 +359,13 @@ class Tensor:
         if mode not in self._mode_steps:
             self._mode_steps[mode] = ModeSteps(mode)
 
-    def add_step(self, mode, mode_step, worker, location):
+    def add_step(self, mode, mode_step, worker, tensor_location, tensor_shape):
         self._create_mode_step(mode, mode_step)
-        self._mode_steps[mode].set_step_location(mode_step, worker, location)
+        if tensor_location is not None:
+            self._mode_steps[mode].set_step_location(mode_step, worker, tensor_location)
+        if tensor_shape is not None:
+            self._mode_steps[mode].set_step_shape(mode_step, worker, tensor_shape.shape)
+            self.original_name = tensor_shape.original_name
 
     def add_reduction_step(self, mode, mode_step, worker, red_name, abs, red_location):
         self._create_mode_step(mode, mode_step)

--- a/smdebug/core/tfevent/index_file_writer.py
+++ b/smdebug/core/tfevent/index_file_writer.py
@@ -13,6 +13,7 @@ class IndexWriter(object):
         self.file_path = file_path
         self.index_payload = []
         self.index_meta = {}
+        self.shape_payload = []
         self.writer = None
 
     def __exit__(self):
@@ -28,13 +29,20 @@ class IndexWriter(object):
     def add_index(self, tensorlocation):
         if not self.writer:
             self._init_writer()
-        if not self.index_meta:
+        if not self.index_meta or not "event_file_name" in self.index_meta:
             self.index_meta = {
                 "mode": tensorlocation.mode,
                 "mode_step": tensorlocation.mode_step,
                 "event_file_name": tensorlocation.event_file_name,
             }
         self.index_payload.append(tensorlocation.to_dict())
+
+    def add_shape(self, tensorshape):
+        if not self.writer:
+            self._init_writer()
+        if not self.index_meta:
+            self.index_meta = {"mode": tensorshape.mode, "mode_step": tensorshape.mode_step}
+        self.shape_payload.append(tensorshape.to_dict())
 
     def flush(self):
         """Flushes the event string to file."""
@@ -44,33 +52,45 @@ class IndexWriter(object):
             raise ValueError(
                 f"Cannot write empty index_meta={self.index_meta} to file {self.file_path}"
             )
-        if not self.index_payload:
+        if not self.index_payload and not self.shape_payload:
             raise ValueError(
-                f"Cannot write empty index_payload={self.index_payload} to file {self.file_path}"
+                f"Cannot write empty payload: index_payload={self.index_payload}, shape_payload={self.shape_payload} to file {self.file_path}"
             )
 
-        index = Index(meta=self.index_meta, tensor_payload=self.index_payload)
+        index = Index(
+            meta=self.index_meta,
+            tensor_payload=self.index_payload,
+            shape_payload=self.shape_payload,
+        )
         self.writer.write(index.to_json())
         self.writer.flush()
         self.index_meta = {}
-        self.index_payload = {}
+        self.index_payload = []
+        self.shape_payload = []
 
     def close(self):
         """Closes the record writer."""
         if self.writer is not None:
-            if self.index_meta and self.index_payload:
+            if self.index_meta and (self.index_payload or self.shape_payload):
                 self.flush()
                 self.writer.close()
                 self.writer = None
 
 
 class Index:
-    def __init__(self, meta=None, tensor_payload=None):
+    def __init__(self, meta=None, tensor_payload=None, shape_payload=None):
         self.meta = meta
         self.tensor_payload = tensor_payload
+        self.shape_payload = shape_payload
 
     def to_json(self):
-        return json.dumps({"meta": self.meta, "tensor_payload": self.tensor_payload})
+        return json.dumps(
+            {
+                "meta": self.meta,
+                "tensor_payload": self.tensor_payload,
+                "shape_payload": self.shape_payload,
+            }
+        )
 
 
 class EventWithIndex(object):

--- a/smdebug/core/writer.py
+++ b/smdebug/core/writer.py
@@ -256,7 +256,9 @@ class ShapeWriter(BaseWriter):
         if not self._writer:
             raise ValueError(f"Cannot flush because self._writer={self._writer}")
         if not self.shapes:
-            raise ValueError(f"Cannot write shapes to file {self.file_path} as it is empty")
+            raise ValueError(
+                f"Cannot write shapes to file {self.file_path} as it is empty. {self.shapes}"
+            )
 
         s = json.dumps({"meta": self.meta, "payload": self.shapes})
         self._writer.write(s)
@@ -268,6 +270,7 @@ class ShapeWriter(BaseWriter):
         """Flushes the event file to disk and close the file.
         """
         if self._writer is not None:
-            self.flush()
-            self._writer.close()
-            self._writer = None
+            if self.shapes:
+                self.flush()
+                self._writer.close()
+                self._writer = None

--- a/smdebug/core/writer.py
+++ b/smdebug/core/writer.py
@@ -17,11 +17,9 @@
 
 """APIs for logging data in the event file."""
 # Standard Library
-import json
 from typing import Tuple
 
 # First Party
-from smdebug.core.access_layer import TSAccessFile, TSAccessS3
 from smdebug.core.modes import MODE_PLUGIN_NAME, MODE_STEP_PLUGIN_NAME
 from smdebug.core.tfevent.event_file_writer import EventFileWriter
 from smdebug.core.tfevent.index_file_writer import IndexWriter
@@ -34,7 +32,6 @@ from smdebug.core.tfevent.summary import (
     scalar_summary,
 )
 from smdebug.core.tfevent.util import make_tensor_proto
-from smdebug.core.utils import is_s3
 
 # Local
 from .locations import (

--- a/smdebug/core/writer.py
+++ b/smdebug/core/writer.py
@@ -260,7 +260,7 @@ class ShapeWriter(BaseWriter):
         self, name, shape: Tuple[int], mode=ModeKeys.GLOBAL, mode_step=None, original_name=None
     ):
         self._index_writer.add_shape(
-            TensorShape(name, mode, mode_step, shape, original_name=original_name)
+            TensorShape(name, mode.name, mode_step, shape, original_name=original_name)
         )
 
     def flush(self):

--- a/smdebug/exceptions.py
+++ b/smdebug/exceptions.py
@@ -68,6 +68,21 @@ class TensorUnavailableForStep(Exception):
         return msg
 
 
+class ShapeUnavailableForStep(Exception):
+    def __init__(self, tname, step, mode=modes.GLOBAL):
+        self.step = step
+        self.mode = mode
+        self.tname = tname
+
+    def __str__(self):
+        msg = (
+            "Shape for tensor {} is not available for step {} "
+            "with mode {} as it was not saved."
+            "".format(self.tname, self.step, self.mode.name)
+        )
+        return msg
+
+
 class TensorUnavailable(Exception):
     def __init__(self, tname):
         self.tname = tname

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -341,6 +341,11 @@ class TensorflowBaseHook(BaseHook):
         else:
             raise NotImplementedError
 
+        if self._saving_shapes_in_step():
+            self.shape_writer = ShapeWriter(
+                trial_dir=self.out_dir, step=self.step, worker=self.worker
+            )
+
     def _close_writers(self) -> None:
         if self.dry_run:
             return
@@ -372,6 +377,9 @@ class TensorflowBaseHook(BaseHook):
                 to_delete_writers.append(mode)
         for mode in to_delete_writers:
             del self.tb_writers[mode]
+
+        self.shape_writer.close()
+        self.shape_writer = None
 
     def _export_model(self):
         tb_writer = self._maybe_get_tb_writer()

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -378,8 +378,9 @@ class TensorflowBaseHook(BaseHook):
         for mode in to_delete_writers:
             del self.tb_writers[mode]
 
-        self.shape_writer.close()
-        self.shape_writer = None
+        if self.shape_writer is not None:
+            self.shape_writer.close()
+            self.shape_writer = None
 
     def _export_model(self):
         tb_writer = self._maybe_get_tb_writer()

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -342,9 +342,12 @@ class TensorflowBaseHook(BaseHook):
             raise NotImplementedError
 
         if self._saving_shapes_in_step():
-            self.shape_writer = ShapeWriter(
-                trial_dir=self.out_dir, step=self.step, worker=self.worker
-            )
+            if self.shape_writer is None or only_initialize_if_missing is False:
+                self.shape_writer = ShapeWriter(
+                    trial_dir=self.out_dir, step=self.step, worker=self.worker
+                )
+        else:
+            assert self.shape_writer is None
 
     def _close_writers(self) -> None:
         if self.dry_run:

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -16,7 +16,7 @@ from smdebug.core.modes import ModeKeys
 from smdebug.core.reductions import get_numpy_reduction, get_reduction_tensor_name
 from smdebug.core.tfevent.util import make_numpy_array
 from smdebug.core.utils import serialize_tf_device
-from smdebug.core.writer import FileWriter
+from smdebug.core.writer import FileWriter, ShapeWriter
 
 # Local
 from .collection import CollectionKeys, CollectionManager

--- a/smdebug/trials/local_trial.py
+++ b/smdebug/trials/local_trial.py
@@ -34,7 +34,7 @@ class LocalTrial(Trial):
         self.index_reader = LocalIndexReader(self.path)
         self.logger.info(f"Loading trial {name} at path {self.trial_dir}")
         self._load_collections()
-        self._load_tensors()
+        self.refresh_data()
 
     def _get_collection_files(self) -> list:
         return list_collection_files_in_directory(get_path_to_collections(self.path))

--- a/smdebug/trials/local_trial.py
+++ b/smdebug/trials/local_trial.py
@@ -39,12 +39,6 @@ class LocalTrial(Trial):
     def _get_collection_files(self) -> list:
         return list_collection_files_in_directory(get_path_to_collections(self.path))
 
-    def _load_tensors_from_index_tensors(self, index_tensors_dict):
-        for tname in index_tensors_dict:
-            for step, itds in index_tensors_dict[tname].items():
-                for worker in itds:
-                    self._add_tensor(int(step), worker, itds[worker]["tensor_location"])
-
     def _read_collections(self, collection_files):
         first_collection_file = collection_files[0]  # First Collection File
         self.collection_manager = CollectionManager.load(first_collection_file)

--- a/smdebug/trials/s3_trial.py
+++ b/smdebug/trials/s3_trial.py
@@ -45,7 +45,7 @@ class S3Trial(Trial):
         self.path = "s3://" + os.path.join(self.bucket_name, self.prefix_name)
         self.index_reader = S3IndexReader(self.path)
         self._load_collections()
-        self._load_tensors()
+        self.refresh_data()
 
     def _get_collection_files(self) -> list:
         collection_files, _ = list_s3_objects(

--- a/smdebug/trials/s3_trial.py
+++ b/smdebug/trials/s3_trial.py
@@ -56,12 +56,6 @@ class S3Trial(Trial):
         )
         return collection_files
 
-    def _load_tensors_from_index_tensors(self, index_tensors_dict):
-        for tname in index_tensors_dict:
-            for step, itds in index_tensors_dict[tname].items():
-                for worker in itds:
-                    self._add_tensor(int(step), worker, itds[worker]["tensor_location"])
-
     def _read_collections(self, collection_files):
         first_collection_file = collection_files[0]  # First Collection File
         key = os.path.join(first_collection_file)

--- a/smdebug/trials/trial.py
+++ b/smdebug/trials/trial.py
@@ -14,7 +14,7 @@ from smdebug.core.config_constants import (
     TRAINING_END_DELAY_REFRESH_DEFAULT,
     TRAINING_END_DELAY_REFRESH_KEY,
 )
-from smdebug.core.locations import IndexFileLocationUtils, TensorLocation
+from smdebug.core.locations import IndexFileLocationUtils, TensorLocation, TensorShape
 from smdebug.core.logger import get_logger
 from smdebug.core.modes import ModeKeys
 from smdebug.core.reductions import REDUCTIONS_PREFIX, reverse_reduction_tensor_name
@@ -231,14 +231,14 @@ class Trial(ABC):
             self.maybe_refresh(tname)
         return tname in self._tensors
 
-    def _populate_step_dict(self, tensor_object, step_num):
-        if tensor_object.mode != ModeKeys.GLOBAL:
-            if tensor_object.mode not in self._mode_to_global:
-                self._mode_to_global[tensor_object.mode] = {}
-            if tensor_object.mode_step not in self._mode_to_global[tensor_object.mode]:
-                self._mode_to_global[tensor_object.mode][tensor_object.mode_step] = int(step_num)
+    def _populate_step_dict(self, mode, mode_step, step_num):
+        if mode != ModeKeys.GLOBAL:
+            if mode not in self._mode_to_global:
+                self._mode_to_global[mode] = {}
+            if mode_step not in self._mode_to_global[mode]:
+                self._mode_to_global[mode][mode_step] = int(step_num)
         if step_num not in self._global_to_mode:
-            self._global_to_mode[step_num] = (tensor_object.mode, tensor_object.mode_step)
+            self._global_to_mode[step_num] = (mode, mode_step)
 
     def _populate_workers_for_global_step(self, step, worker) -> None:
         """
@@ -263,7 +263,7 @@ class Trial(ABC):
             self.last_complete_step = step
             self.logger.debug(f"Populating last completing step to: {step}")
 
-    def _populate_global_step_to_tensor_name_map(self, tensor: TensorLocation, step_num) -> None:
+    def _populate_global_step_to_tensor_name_map(self, tensorname: str, step_num) -> None:
         """
         The self.global_step_to_tensors_map dictionary holds a mapping of
         step number and a set of all the tensor names that have been written for the step.
@@ -274,47 +274,67 @@ class Trial(ABC):
         """
         if step_num not in self.global_step_to_tensors_map:
             self.global_step_to_tensors_map[step_num] = set()
-        self.global_step_to_tensors_map[step_num].add(tensor.tensorname)
+        self.global_step_to_tensors_map[step_num].add(tensorname)
 
-    def _populate_mode_to_tensor_name_map(self, tensor: TensorLocation) -> None:
+    def _populate_mode_to_tensor_name_map(self, tensorname, mode) -> None:
         """
         The self.mode_to_tensors_map dictionary holds a mapping of
         mode and a set of all the tensor names that have been written for the mode.
         :param tensor:
         :return:
         """
-        if tensor.mode != ModeKeys.GLOBAL:
-            if tensor.mode not in self.mode_to_tensors_map:
-                self.mode_to_tensors_map[tensor.mode] = set()
-            self.mode_to_tensors_map[tensor.mode].add(tensor.tensorname)
+        if mode != ModeKeys.GLOBAL:
+            if mode not in self.mode_to_tensors_map:
+                self.mode_to_tensors_map[mode] = set()
+            self.mode_to_tensors_map[mode].add(tensorname)
 
-    def _add_tensor(self, step_num, worker, tensor_object: TensorLocation):
+    def _load_tensors_from_index_tensors(self, index_tensors_dict):
+        for tname in index_tensors_dict:
+            for step, itds in index_tensors_dict[tname].items():
+                for worker in itds:
+                    self._add_tensor(
+                        int(step),
+                        worker,
+                        itds[worker].get("tensor_location", None),
+                        itds[worker].get("tensor_shape", None),
+                    )
+
+    def _add_tensor(
+        self, step_num, worker, tensor_location: TensorLocation, tensor_shape: TensorShape
+    ):
         is_reduction = False
 
-        if REDUCTIONS_PREFIX in tensor_object.tensorname:
-            tname, red_name, abs = reverse_reduction_tensor_name(tensor_object.tensorname)
-            tensor_object.tensorname = tname
-            is_reduction = True
+        if tensor_location is not None:
+            tensorname = tensor_location.tensorname
+            mode = tensor_location.mode
+            mode_step = tensor_location.mode_step
+        elif tensor_shape is not None:
+            tensorname = tensor_shape.name
+            mode = tensor_shape.mode
+            mode_step = tensor_shape.mode_step
         else:
-            tname = tensor_object.tensorname
+            raise RuntimeError("both tensor_location and tensor_shape can't be None")
 
-        if tname not in self._tensors:
-            tensor = Tensor(tname, trial=self, cache=self.cache)
-            self._tensors[tname] = tensor
+        if REDUCTIONS_PREFIX in tensorname:
+            tensorname, red_name, abs = reverse_reduction_tensor_name(tensorname)
+            is_reduction = True
 
-        tensor = self._tensors[tname]
+        if tensorname not in self._tensors:
+            tensor = Tensor(tensorname, trial=self, cache=self.cache)
+            self._tensors[tensorname] = tensor
+
+        tensor = self._tensors[tensorname]
 
         if is_reduction:
-            tensor.add_reduction_step(
-                tensor_object.mode, tensor_object.mode_step, worker, red_name, abs, tensor_object
-            )
+            tensor.add_reduction_step(mode, mode_step, worker, red_name, abs, tensor_location)
         else:
-            tensor.add_step(tensor_object.mode, tensor_object.mode_step, worker, tensor_object)
+            # shape can only be passed for actual tensor, not reductions
+            tensor.add_step(mode, mode_step, worker, tensor_location, tensor_shape)
 
-        self._populate_step_dict(tensor_object, step_num)
-        self._populate_global_step_to_tensor_name_map(tensor_object, step_num)
+        self._populate_step_dict(mode, mode_step, step_num)
+        self._populate_global_step_to_tensor_name_map(tensorname, step_num)
         self._populate_workers_for_global_step(step_num, worker)
-        self._populate_mode_to_tensor_name_map(tensor_object)
+        self._populate_mode_to_tensor_name_map(tensorname, mode)
 
     def _tensors_matching_regex(self, regex_list) -> set:
         matched_tensornames = set()

--- a/smdebug/trials/trial.py
+++ b/smdebug/trials/trial.py
@@ -190,7 +190,7 @@ class Trial(ABC):
             retry_count = 2
         while retry_count > 0:
             if name is None:
-                self.refresh_tensors()
+                self.refresh_data()
             else:
                 self.refresh_tensor(name)
             if retry_count > 1:
@@ -215,7 +215,7 @@ class Trial(ABC):
 
     def refresh_tensor(self, tname, steps=None):
         # for now we load all tensors at once
-        self.refresh_tensors()
+        self.refresh_data()
 
     def tensor(self, tname):
         # will not show tensor if it was not written yet
@@ -560,10 +560,6 @@ class Trial(ABC):
             return StepState.UNAVAILABLE
         return StepState.NOT_YET_AVAILABLE
 
-    def _load_tensors(self):
-        if self.index_mode:
-            self._load_tensors_from_index_files()
-
     def _update_last_index_token(self, new_index_token: str) -> None:
         """
         This function updates the last_index_token in the following scenarios:
@@ -625,15 +621,7 @@ class Trial(ABC):
                 f"Updating last_complete_step to: {self.last_complete_step}. "
             )
 
-    def _load_tensors_from_index_files(self):
-        self.index_tensors_dict, new_index_token = self.index_reader.load_tensor_data_from_index_files(
-            start_after_key=self.last_index_token, range_steps=self.range_steps
-        )
-        self._load_tensors_from_index_tensors(self.index_tensors_dict)
-        if new_index_token:  # new index token can be None if there are no new index files
-            self._update_last_index_token(new_index_token)
-
-    def refresh_tensors(self):
+    def refresh_data(self):
         # TODO if job finished
         if self.index_mode:
             index_tensors_dict, new_index_token = self.index_reader.load_tensor_data_from_index_files(

--- a/tests/mxnet/test_hook_reduce_config.py
+++ b/tests/mxnet/test_hook_reduce_config.py
@@ -100,30 +100,8 @@ def test_save_shapes(out_dir, hook=None):
             reduction_config=global_reduce_config,
         )
     run_mnist_gluon_model(hook=hook, num_steps_train=5)
-    verify_shapes(
-        out_dir,
-        0,
-        [
-            "dense0_relu_input_0",
-            "dense0_relu_output_0",
-            "pool1_output_0",
-            "gradient/dense0_weight",
-            "conv0_weight",
-            "softmaxcrossentropyloss0_input_0",
-        ],
-    )
-    verify_shapes(
-        out_dir,
-        1,
-        [
-            "dense0_relu_input_0",
-            "dense0_relu_output_0",
-            "pool1_output_0",
-            "gradient/dense0_weight",
-            "conv0_weight",
-            "softmaxcrossentropyloss0_input_0",
-        ],
-    )
+    verify_shapes(out_dir, 0)
+    verify_shapes(out_dir, 1)
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/mxnet/test_hook_reduce_config.py
+++ b/tests/mxnet/test_hook_reduce_config.py
@@ -86,24 +86,20 @@ def test_save_config(hook=None, out_dir=None):
         shutil.rmtree(out_dir)
 
 
-def test_save_shapes(out_dir, hook=None):
-    hook_created = False
-    if hook is None:
-        hook_created = True
-        global_reduce_config = ReductionConfig(save_shape=True)
-        global_save_config = SaveConfig(save_steps=[0, 1])
+def test_save_shapes(out_dir):
+    global_reduce_config = ReductionConfig(save_shape=True)
+    global_save_config = SaveConfig(save_steps=[0, 1])
 
-        hook = t_hook(
-            out_dir=out_dir,
-            save_config=global_save_config,
-            save_all=True,
-            reduction_config=global_reduce_config,
-        )
+    hook = t_hook(
+        out_dir=out_dir,
+        save_config=global_save_config,
+        save_all=True,
+        reduction_config=global_reduce_config,
+    )
     run_mnist_gluon_model(hook=hook, num_steps_train=5)
     verify_shapes(out_dir, 0)
     verify_shapes(out_dir, 1)
-    if hook_created:
-        shutil.rmtree(out_dir)
+    shutil.rmtree(out_dir)
 
 
 def test_save_config_hook_from_json():

--- a/tests/mxnet/test_hook_reduce_config.py
+++ b/tests/mxnet/test_hook_reduce_config.py
@@ -100,8 +100,30 @@ def test_save_shapes(out_dir, hook=None):
             reduction_config=global_reduce_config,
         )
     run_mnist_gluon_model(hook=hook, num_steps_train=5)
-    verify_shapes(out_dir, 0, 40, exact_equal=False)
-    verify_shapes(out_dir, 1, 40, exact_equal=False)
+    verify_shapes(
+        out_dir,
+        0,
+        [
+            "dense0_relu_input_0",
+            "dense0_relu_output_0",
+            "pool1_output_0",
+            "gradient/dense0_weight",
+            "conv0_weight",
+            "softmaxcrossentropyloss0_input_0",
+        ],
+    )
+    verify_shapes(
+        out_dir,
+        1,
+        [
+            "dense0_relu_input_0",
+            "dense0_relu_output_0",
+            "pool1_output_0",
+            "gradient/dense0_weight",
+            "conv0_weight",
+            "softmaxcrossentropyloss0_input_0",
+        ],
+    )
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/mxnet/test_hook_reduce_config.py
+++ b/tests/mxnet/test_hook_reduce_config.py
@@ -100,8 +100,8 @@ def test_save_shapes(out_dir, hook=None):
             reduction_config=global_reduce_config,
         )
     run_mnist_gluon_model(hook=hook, num_steps_train=5)
-    verify_shapes(out_dir, 0, 49)
-    verify_shapes(out_dir, 1, 49)
+    verify_shapes(out_dir, 0, 40, exact_equal=False)
+    verify_shapes(out_dir, 1, 40, exact_equal=False)
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/pytorch/test_json_configs/test_hook_save_shape.json
+++ b/tests/pytorch/test_json_configs/test_hook_save_shape.json
@@ -1,0 +1,9 @@
+{
+    "S3Path": "s3://kjndjknd_bucket/prefix",
+    "LocalPath": "/tmp/test_output/test_hook_save_shape/jsonloading",
+    "HookParameters": {
+      "save_all": true,
+      "save_shape": true,
+      "save_steps": "0,1"
+    }
+  }

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -150,7 +150,9 @@ def test_save_shapes(hook=None, out_dir=None):
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device("cpu"), optimizer, num_steps=10)
     # different versions seem to output different number of loss tensors
-    verify_shapes(out_dir, 0, 41, exact_equal=False)
+    verify_shapes(
+        out_dir, 0, ["conv2_input_0", "NestedNet_fc1.bias", "gradient/NestedNet_conv2.weight"]
+    )
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -154,6 +154,19 @@ def test_save_shapes(hook=None, out_dir=None):
         shutil.rmtree(out_dir)
 
 
+def test_save_shapes_json():
+    from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
+
+    out_dir = "/tmp/test_output/test_hook_save_shape/jsonloading"
+    shutil.rmtree(out_dir, True)
+    os.environ[
+        CONFIG_FILE_PATH_ENV_STR
+    ] = "tests/pytorch/test_json_configs/test_hook_save_shape.json"
+    hook = t_hook.create_from_json_file()
+    test_save_shapes(hook=hook, out_dir=out_dir)
+    shutil.rmtree(out_dir, True)
+
+
 # Test creating hook by loading the json file with reduction configs.
 def test_reduce_config_with_json():
     from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -150,9 +150,7 @@ def test_save_shapes(hook=None, out_dir=None):
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device("cpu"), optimizer, num_steps=10)
     # different versions seem to output different number of loss tensors
-    verify_shapes(
-        out_dir, 0, ["conv2_input_0", "NestedNet_fc1.bias", "gradient/NestedNet_conv2.weight"]
-    )
+    verify_shapes(out_dir, 0)
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -149,7 +149,7 @@ def test_save_shapes(hook=None, out_dir=None):
     hook.register_module(model)
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device("cpu"), optimizer, num_steps=10)
-    # different versions seem to output different tensors
+    # different versions seem to output different number of loss tensors
     verify_shapes(out_dir, 0, 41, exact_equal=False)
     if hook_created:
         shutil.rmtree(out_dir)

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -149,7 +149,8 @@ def test_save_shapes(hook=None, out_dir=None):
     hook.register_module(model)
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device("cpu"), optimizer, num_steps=10)
-    verify_shapes(out_dir, 0, 41)
+    # different versions seem to output different tensors
+    verify_shapes(out_dir, 0, 41, exact_equal=False)
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/pytorch/test_reduce_config.py
+++ b/tests/pytorch/test_reduce_config.py
@@ -149,7 +149,7 @@ def test_save_shapes(hook=None, out_dir=None):
     hook.register_module(model)
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     train(model, hook, torch.device("cpu"), optimizer, num_steps=10)
-    verify_shapes(out_dir, 0, 4)
+    verify_shapes(out_dir, 0, 41)
     if hook_created:
         shutil.rmtree(out_dir)
 

--- a/tests/tensorflow/hooks/test_estimator_modes.py
+++ b/tests/tensorflow/hooks/test_estimator_modes.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from tests.analysis.utils import delete_s3_prefix
+from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.utils import verify_shapes
 
 # First Party
@@ -209,7 +210,15 @@ def test_mnist_shapes(out_dir, on_s3=False):
         steps=None,
         reduction_config=smd.ReductionConfig(save_shape=True),
     )
-    verify_shapes(out_dir, 0, 249)
+    verify_shapes(
+        out_dir,
+        0,
+        [
+            "conv2d/kernel:0",
+            "gradients/sparse_softmax_cross_entropy_loss/value_grad/Sum:0",
+            "dense_1/kernel:0",
+        ],
+    )
 
 
 @pytest.mark.slow  # 0:02 to run

--- a/tests/tensorflow/hooks/test_estimator_modes.py
+++ b/tests/tensorflow/hooks/test_estimator_modes.py
@@ -213,6 +213,11 @@ def test_mnist_shapes(out_dir, on_s3=False):
 
 
 @pytest.mark.slow  # 0:02 to run
+def test_mnist_shapes_s3(out_dir):
+    test_mnist_shapes(out_dir, on_s3=True)
+
+
+@pytest.mark.slow  # 0:02 to run
 def test_mnist_local_json(out_dir, monkeypatch):
     monkeypatch.setenv(
         CONFIG_FILE_PATH_ENV_STR, "tests/tensorflow/hooks/test_json_configs/test_mnist_local.json"

--- a/tests/tensorflow/hooks/test_estimator_modes.py
+++ b/tests/tensorflow/hooks/test_estimator_modes.py
@@ -210,15 +210,7 @@ def test_mnist_shapes(out_dir, on_s3=False):
         steps=None,
         reduction_config=smd.ReductionConfig(save_shape=True),
     )
-    verify_shapes(
-        out_dir,
-        0,
-        [
-            "conv2d/kernel:0",
-            "gradients/sparse_softmax_cross_entropy_loss/value_grad/Sum:0",
-            "dense_1/kernel:0",
-        ],
-    )
+    verify_shapes(out_dir, 0)
 
 
 @pytest.mark.slow  # 0:02 to run

--- a/tests/tensorflow/hooks/test_estimator_modes.py
+++ b/tests/tensorflow/hooks/test_estimator_modes.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from tests.analysis.utils import delete_s3_prefix
+from tests.utils import verify_shapes
 
 # First Party
 import smdebug.tensorflow as smd
@@ -30,10 +31,12 @@ from smdebug.trials import create_trial
 def help_test_mnist(
     path,
     save_config=None,
+    reduction_config=None,
     hook=None,
     set_modes=True,
     num_steps=10,
     num_eval_steps=None,
+    save_all=False,
     steps=None,
     include_collections=None,
 ):
@@ -125,7 +128,11 @@ def help_test_mnist(
         if include_collections is None:
             include_collections = ["weights", "gradients", "default", "losses"]
         hook = smd.SessionHook(
-            out_dir=trial_dir, save_config=save_config, include_collections=include_collections
+            out_dir=trial_dir,
+            save_config=save_config,
+            include_collections=include_collections,
+            save_all=save_all,
+            reduction_config=reduction_config,
         )
 
     if num_eval_steps is None:
@@ -185,6 +192,24 @@ def test_mnist(out_dir, on_s3=False):
         out_dir = f"s3://{bucket}/{prefix}"
     help_test_mnist(out_dir, save_config=smd.SaveConfig(save_interval=2), num_steps=2, steps=None)
     helper_test_mnist_trial(out_dir)
+
+
+@pytest.mark.slow  # 0:02 to run
+def test_mnist_shapes(out_dir, on_s3=False):
+    if on_s3:
+        run_id = "trial_" + datetime.now().strftime("%Y%m%d-%H%M%S%f")
+        bucket = "smdebug-testing"
+        prefix = "outputs/hooks/estimator_modes/" + run_id
+        out_dir = f"s3://{bucket}/{prefix}"
+    help_test_mnist(
+        out_dir,
+        save_all=True,
+        save_config=smd.SaveConfig(save_steps=[0]),
+        num_steps=1,
+        steps=None,
+        reduction_config=smd.ReductionConfig(save_shape=True),
+    )
+    verify_shapes(out_dir, 0, 249)
 
 
 @pytest.mark.slow  # 0:02 to run

--- a/tests/tensorflow/hooks/test_estimator_modes.py
+++ b/tests/tensorflow/hooks/test_estimator_modes.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from tests.analysis.utils import delete_s3_prefix
-from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.utils import verify_shapes
 
 # First Party

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -1,7 +1,7 @@
 # Standard Library
 
 # Third Party
-from tests.tensorflow2.utils import verify_shapes
+from tests.utils import verify_shapes
 
 # First Party
 import smdebug.tensorflow as smd

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -70,11 +70,7 @@ def test_shapes(out_dir, save_raw_tensor=False):
         include_collections=["weights", "gradients", "losses"],
     )
     simple_model(hook)
-    verify_shapes(
-        out_dir,
-        0,
-        ["foobar/weight1:0", "gradients/MatMul_grad/tuple/control_dependency_1:0", "loss:0"],
-    )
+    verify_shapes(out_dir, 0)
 
 
 def test_reductions_with_raw_tensor(out_dir):

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -70,7 +70,7 @@ def test_shapes(out_dir, save_raw_tensor=False):
         include_collections=["weights", "gradients", "losses"],
     )
     simple_model(hook)
-    verify_shapes(out_dir, 0, 2)
+    verify_shapes(out_dir, 0, 3)
 
 
 def test_reductions_with_raw_tensor(out_dir):

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -70,7 +70,11 @@ def test_shapes(out_dir, save_raw_tensor=False):
         include_collections=["weights", "gradients", "losses"],
     )
     simple_model(hook)
-    verify_shapes(out_dir, 0, 3)
+    verify_shapes(
+        out_dir,
+        0,
+        ["foobar/weight1:0", "gradients/MatMul_grad/tuple/control_dependency_1:0", "loss:0"],
+    )
 
 
 def test_reductions_with_raw_tensor(out_dir):

--- a/tests/tensorflow/hooks/test_reductions.py
+++ b/tests/tensorflow/hooks/test_reductions.py
@@ -1,5 +1,8 @@
 # Standard Library
 
+# Third Party
+from tests.tensorflow2.utils import verify_shapes
+
 # First Party
 import smdebug.tensorflow as smd
 from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
@@ -55,6 +58,19 @@ def test_reductions(out_dir, save_raw_tensor=False):
         include_collections=["weights", "gradients", "losses"],
     )
     helper_test_reductions(out_dir, hook, save_raw_tensor)
+
+
+def test_shapes(out_dir, save_raw_tensor=False):
+    pre_test_clean_up()
+    rdnc = smd.ReductionConfig(save_shape=True, save_raw_tensor=save_raw_tensor)
+    hook = smd.SessionHook(
+        out_dir=out_dir,
+        save_config=smd.SaveConfig(save_interval=1),
+        reduction_config=rdnc,
+        include_collections=["weights", "gradients", "losses"],
+    )
+    simple_model(hook)
+    verify_shapes(out_dir, 0, 2)
 
 
 def test_reductions_with_raw_tensor(out_dir):

--- a/tests/tensorflow/keras/test_keras.py
+++ b/tests/tensorflow/keras/test_keras.py
@@ -236,7 +236,9 @@ def test_tf_keras_shapes(out_dir):
         eager=False,
         steps=["train", "eval", "predict", "train"],
     )
-    verify_shapes(out_dir, 0, 21)
+    verify_shapes(
+        out_dir, 0, ["training/RMSprop/momentum:0", "dense/weights/dense/kernel:0", "batch", "loss"]
+    )
 
 
 @pytest.mark.slow  # 0:03 to run

--- a/tests/tensorflow/keras/test_keras.py
+++ b/tests/tensorflow/keras/test_keras.py
@@ -236,9 +236,7 @@ def test_tf_keras_shapes(out_dir):
         eager=False,
         steps=["train", "eval", "predict", "train"],
     )
-    verify_shapes(
-        out_dir, 0, ["training/RMSprop/momentum:0", "dense/weights/dense/kernel:0", "batch", "loss"]
-    )
+    verify_shapes(out_dir, 0)
 
 
 @pytest.mark.slow  # 0:03 to run

--- a/tests/tensorflow/keras/test_keras.py
+++ b/tests/tensorflow/keras/test_keras.py
@@ -5,6 +5,7 @@ import shutil
 import pytest
 import tensorflow as tf
 from tests.tensorflow.utils import create_trial_fast_refresh
+from tests.utils import verify_shapes
 
 # First Party
 from smdebug.core.access_layer import has_training_ended
@@ -222,6 +223,20 @@ def test_keras(out_dir):
 @pytest.mark.slow  # 0:07 to run
 def test_tf_keras(out_dir):
     exhaustive_check(out_dir, True)
+
+
+@pytest.mark.slow  # 0:07 to run
+def test_tf_keras_shapes(out_dir):
+    train_model(
+        out_dir,
+        save_all=True,
+        reduction_config=ReductionConfig(save_shape=True),
+        use_tf_keras=True,
+        save_config=SaveConfig(save_steps=[0, 10]),
+        eager=False,
+        steps=["train", "eval", "predict", "train"],
+    )
+    verify_shapes(out_dir, 0, 21)
 
 
 @pytest.mark.slow  # 0:03 to run

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -474,7 +474,7 @@ def test_keras_fit_shapes(out_dir):
     )
     helper_keras_fit(trial_dir=out_dir, hook=hook)
     print(create_trial_fast_refresh(out_dir).tensor_names(step=0))
-    verify_shapes(out_dir, 0, ["dense/weights/dense/kernel:0", "accuracy", "Adam/beta_1:0"])
+    verify_shapes(out_dir, 0)
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -191,8 +191,8 @@ def test_keras_gradtape_shapes(out_dir):
         reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_gradtape(trial_dir=out_dir, hook=hook)
-    verify_shapes(out_dir, 0, 10)
-    verify_shapes(out_dir, 500, 15)
+    verify_shapes(out_dir, 0, ["gradients/dense_1/biasGrad", "weights/dense/bias:0", "loss"])
+    verify_shapes(out_dir, 500, ["weights/dense/bias:0", "Adam/learning_rate:0", "loss"])
 
 
 @pytest.mark.skip_if_non_eager
@@ -473,7 +473,8 @@ def test_keras_fit_shapes(out_dir):
         reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_fit(trial_dir=out_dir, hook=hook)
-    verify_shapes(out_dir, 0, 12)
+    print(create_trial_fast_refresh(out_dir).tensor_names(step=0))
+    verify_shapes(out_dir, 0, ["dense/weights/dense/kernel:0", "accuracy", "Adam/beta_1:0"])
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -23,6 +23,7 @@ import smdebug.tensorflow as smd
 from smdebug.core.access_layer import has_training_ended
 from smdebug.core.collection import CollectionKeys
 from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
+from smdebug.core.locations import ShapeFileLocation
 from smdebug.core.modes import ModeKeys
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.exceptions import TensorUnavailableForStep

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -22,6 +22,7 @@ from tests.utils import use_s3_datasets
 import smdebug.tensorflow as smd
 from smdebug.core.access_layer import has_training_ended
 from smdebug.core.collection import CollectionKeys
+from smdebug.core.config_constants import DEFAULT_WORKER_NAME
 from smdebug.core.json_config import CONFIG_FILE_PATH_ENV_STR
 from smdebug.core.locations import ShapeFileLocation
 from smdebug.core.modes import ModeKeys

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -191,8 +191,8 @@ def test_keras_gradtape_shapes(out_dir):
         reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_gradtape(trial_dir=out_dir, hook=hook)
-    verify_shapes(out_dir, 0, ["gradients/dense_1/biasGrad", "weights/dense/bias:0", "loss"])
-    verify_shapes(out_dir, 500, ["weights/dense/bias:0", "Adam/learning_rate:0", "loss"])
+    verify_shapes(out_dir, 0)
+    verify_shapes(out_dir, 500)
 
 
 @pytest.mark.skip_if_non_eager

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -186,8 +186,9 @@ def helper_keras_gradtape(
 def test_keras_gradtape_shapes(out_dir):
     hook = smd.KerasHook(
         out_dir=out_dir,
-        save_all=saveall,
-        save_config=SaveConfig(save_steps=[0], reduce_config=ReductionConfig(save_shape=True)),
+        save_all=True,
+        save_config=SaveConfig(save_steps=[0]),
+        reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_gradtape(trial_dir=out_dir, hook=hook)
     sl = ShapeFileLocation(0, DEFAULT_WORKER_NAME)

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -191,8 +191,8 @@ def test_keras_gradtape_shapes(out_dir):
         reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_gradtape(trial_dir=out_dir, hook=hook)
-    verify_shapes(out_dir, 0, 9)
-    verify_shapes(out_dir, 500, 14)
+    verify_shapes(out_dir, 0, 10)
+    verify_shapes(out_dir, 500, 15)
 
 
 @pytest.mark.skip_if_non_eager
@@ -473,7 +473,7 @@ def test_keras_fit_shapes(out_dir):
         reduction_config=ReductionConfig(save_shape=True),
     )
     helper_keras_fit(trial_dir=out_dir, hook=hook)
-    verify_shapes(out_dir, 0, 9)
+    verify_shapes(out_dir, 0, 12)
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -293,7 +293,7 @@ def test_save_all(out_dir, tf_eager_mode, workers):
 
 @pytest.mark.slow
 def test_shapes(out_dir, tf_eager_mode):
-    train_model(
+    strategy, _ = train_model(
         out_dir,
         save_all=True,
         save_config=SaveConfig(save_steps=[0]),
@@ -301,7 +301,8 @@ def test_shapes(out_dir, tf_eager_mode):
         steps=["train"],
         eager=tf_eager_mode,
     )
-    verify_shapes(out_dir, 0, multiworker=True)
+    multiworker = strategy.num_replicas_in_sync > 1
+    verify_shapes(out_dir, 0, multiworker=multiworker)
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -13,6 +13,7 @@ from tensorflow.python.client import device_lib
 from tests.core.utils import verify_files
 from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3
 from tests.tensorflow.utils import create_trial_fast_refresh
+from tests.utils import verify_shapes
 
 # First Party
 import smdebug.tensorflow as smd
@@ -288,6 +289,19 @@ def test_save_all(out_dir, tf_eager_mode, workers):
             1 if workers == "one" else strategy.num_replicas_in_sync
         )
     verify_files(out_dir, save_config, saved_scalars)
+
+
+@pytest.mark.slow
+def test_shapes(out_dir, tf_eager_mode):
+    train_model(
+        out_dir,
+        save_all=True,
+        save_config=SaveConfig(save_steps=[0]),
+        reduction_config=ReductionConfig(save_shape=True),
+        steps=["train"],
+        eager=tf_eager_mode,
+    )
+    verify_shapes(out_dir, 0, 15, multiworker=True)
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -301,7 +301,17 @@ def test_shapes(out_dir, tf_eager_mode):
         steps=["train"],
         eager=tf_eager_mode,
     )
-    verify_shapes(out_dir, 0, 15, multiworker=True)
+    verify_shapes(
+        out_dir,
+        0,
+        [
+            "dense_1/weights/dense_1/kernel:0",
+            "scalar/foobar",
+            "dense/weights/dense/bias:0",
+            "Adam/decay:0",
+        ],
+        multiworker=True,
+    )
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -301,17 +301,7 @@ def test_shapes(out_dir, tf_eager_mode):
         steps=["train"],
         eager=tf_eager_mode,
     )
-    verify_shapes(
-        out_dir,
-        0,
-        [
-            "dense_1/weights/dense_1/kernel:0",
-            "scalar/foobar",
-            "dense/weights/dense/bias:0",
-            "Adam/decay:0",
-        ],
-        multiworker=True,
-    )
+    verify_shapes(out_dir, 0, multiworker=True)
 
 
 @pytest.mark.slow

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,10 +29,13 @@ def use_s3_datasets():
         return False
 
 
-def verify_shapes(out_dir, step_num, num_tensors):
+def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True):
     trial = create_trial(out_dir)
     tnames = trial.tensor_names(step=step_num)
-    assert num_tensors == len(tnames), (len(tnames), tnames)
+    if exact_equal:
+        assert num_tensors == len(tnames), (len(tnames), tnames)
+    else:
+        assert num_tensors >= len(tnames), (len(tnames), tnames)
     for tname in tnames:
         tensor = trial.tensor(tname)
         assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True):
     if exact_equal:
         assert num_tensors == len(tnames), (len(tnames), tnames)
     else:
-        assert num_tensors >= len(tnames), (len(tnames), tnames)
+        assert num_tensors <= len(tnames), (len(tnames), tnames)
     for tname in tnames:
         tensor = trial.tensor(tname)
         assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,9 +40,9 @@ def is_scalar(x):
     return False
 
 
-def verify_shapes(out_dir, step_num, tensornames, multiworker=False):
+def verify_shapes(out_dir, step_num, multiworker=False):
     trial = create_trial_fast_refresh(out_dir)
-    for tname in tensornames:
+    for tname in trial.tensor_names(step=step_num):
         tensor = trial.tensor(tname)
         if multiworker is False:
             assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ def use_s3_datasets():
         return False
 
 
-def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True):
+def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True, multiworker=False):
     trial = create_trial(out_dir)
     tnames = trial.tensor_names(step=step_num)
     if exact_equal:
@@ -38,7 +38,17 @@ def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True):
         assert num_tensors <= len(tnames), (len(tnames), tnames)
     for tname in tnames:
         tensor = trial.tensor(tname)
-        assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))
+        if multiworker is False:
+            assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))
+        else:
+            workers = tensor.workers(step_num)
+            assert len(workers) > 1
+            for w in workers:
+                assert isinstance(tensor.shape(step_num, worker=w), tuple), (
+                    tname,
+                    w,
+                    tensor.shape(step_num, worker=w),
+                )
 
 
 class SagemakerSimulator(object):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 # Standard Library
-import json
 import os
 import shutil
 from pathlib import Path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import boto3
 import numpy as np
 from tests.constants import TEST_DATASET_S3_PATH
+from tests.tensorflow.utils import create_trial_fast_refresh
 
 # First Party
 from smdebug.core.config_constants import (
@@ -18,7 +19,6 @@ from smdebug.core.config_constants import (
 )
 from smdebug.core.utils import is_s3, remove_file_if_exists
 from smdebug.exceptions import TensorUnavailableForStep
-from smdebug.trials import create_trial
 
 
 def use_s3_datasets():
@@ -40,14 +40,9 @@ def is_scalar(x):
     return False
 
 
-def verify_shapes(out_dir, step_num, num_tensors, exact_equal=True, multiworker=False):
-    trial = create_trial(out_dir)
-    tnames = trial.tensor_names(step=step_num)
-    if exact_equal:
-        assert num_tensors == len(tnames), (len(tnames), tnames)
-    else:
-        assert num_tensors <= len(tnames), (len(tnames), tnames)
-    for tname in tnames:
+def verify_shapes(out_dir, step_num, tensornames, multiworker=False):
+    trial = create_trial_fast_refresh(out_dir)
+    for tname in tensornames:
         tensor = trial.tensor(tname)
         if multiworker is False:
             assert isinstance(tensor.shape(step_num), tuple), (tname, tensor.shape(step_num))


### PR DESCRIPTION
### Description of changes:
- Added a config to ReductionConfig to save shape. 
- Created a class ShapeWriter which uses the same index writer as (Event)FileWriter and adds the shapes to the index file. Adding shapes to the index file means that we get index files even when event files doesn't exist. It helps to not create more files though.
- Added an API `shape` to tensor class.
- Added tests for mxnet, tensorflow, pytorch

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
