### PR TITLE
Save tf2 model

### DIFF
--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -329,7 +329,7 @@ class InputOutputSaver:
         self.layer_input = None
         self.layer_output = None
 
-    def __call__(self, callable_inputs, *args, **kwargs) -> None:
+    def __call__(self, inputs, *args, **kwargs) -> None:
         self.layer_input = kwargs["layer_input"]
         self.layer_output = kwargs["layer_output"]
 
@@ -337,11 +337,11 @@ class InputOutputSaver:
 def get_layer_call_fn(layer: tf.keras.layers.Layer) -> Callable[[tf.Tensor], tf.Tensor]:
     old_call_fn = layer.call
 
-    def call(callable_inputs, *args, **kwargs) -> tf.Tensor:
-        layer_input = callable_inputs
-        layer_output = old_call_fn(callable_inputs)
+    def call(inputs, *args, **kwargs) -> tf.Tensor:
+        layer_input = inputs
+        layer_output = old_call_fn(inputs)
         for hook in layer._hooks:
-            hook_result = hook(callable_inputs, layer_input=layer_input, layer_output=layer_output)
+            hook_result = hook(inputs, layer_input=layer_input, layer_output=layer_output)
             if hook_result is not None:
                 layer_output = hook_result
         return layer_output

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -103,6 +103,8 @@ def helper_keras_fit(
         elif step == "predict":
             model.predict(x_test[:100], callbacks=hooks, verbose=0)
 
+    model.save(trial_dir, save_format="tf")
+
     hook.close()
 
 
@@ -180,6 +182,7 @@ def helper_keras_gradtape(
             )
         train_acc_metric.reset_states()
 
+    model.save(trial_dir, save_format="tf")
     hook.close()
 
 


### PR DESCRIPTION
### Description of changes:
Inputs to layers.__call__ are expected to be called "inputs" as self._call_fn_args is by default set to ["inputs"]. Failure to do so results in errors while trying to save the model.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
