### PR TITLE
list training jobs improvements

### DIFF
--- a/smdebug/rules/action/stop_training_action.py
+++ b/smdebug/rules/action/stop_training_action.py
@@ -50,7 +50,7 @@ class StopTrainingAction:
                     self._logger.info(
                         f"No TrainingJob summaries found: list_training_jobs output is : {res}"
                     )
-                    return
+                    return []
                 for job in jobs:
                     tj_status = job["TrainingJobStatus"]
                     tj_name = job["TrainingJobName"]

--- a/smdebug/rules/action/stop_training_action.py
+++ b/smdebug/rules/action/stop_training_action.py
@@ -26,6 +26,7 @@ class StopTrainingAction:
         next_token = None
         name = self._training_job_prefix
         i = 0
+        exception_caught_times = 0
         while i < 50:
             try:
                 if next_token is None:
@@ -61,6 +62,10 @@ class StopTrainingAction:
                 self._logger.info(
                     f"Caught exception while getting list_training_job exception is: \n {e}. Attempt:{i}"
                 )
+                exception_caught_times += 1
+                if exception_caught_times > 5:
+                    print("Got exception more than 5 times while finding training job. Giving up.")
+                    break
             if "NextToken" not in res:
                 break
             else:
@@ -68,6 +73,11 @@ class StopTrainingAction:
                 res = {}
                 jobs = {}
                 i += 1
+            if len(found_job_dict) > 0:
+                print(
+                    f"Found training jobs matching prefix:{name}. Exiting even if next_token:{next_token} was present."
+                )
+                break
 
         return found_job_dict.keys()
 


### PR DESCRIPTION
### Description of changes:
Earlier list training job would make 50 attempts irrespective. This may be bad because of unnecessary traffic. 
We have changed attempts - 
1) if there are training jobs found with prefix, we break
2) if there are exceptions caught more than 5 times we break. 

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
