### PR TITLE
Modify Should Save Tensor Test To Work on Any Version of TF

### DIFF
--- a/tests/tensorflow2/test_should_save_tensor.py
+++ b/tests/tensorflow2/test_should_save_tensor.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 # First Party
 import smdebug.tensorflow as smd
 from smdebug.core.collection import CollectionKeys
+from smdebug.core.modes import ModeKeys
 from smdebug.tensorflow import SaveConfig
 from smdebug.tensorflow.constants import TF_DEFAULT_SAVED_COLLECTIONS
 
@@ -27,6 +28,9 @@ def helper_create_hook(out_dir, collections, include_regex=None):
             hook.get_collection(collection).include(include_regex)
 
     hook.register_model(model)
+    hook.set_mode(ModeKeys.TRAIN)
+    hook._prepare_collections()
+    hook._increment_step()
     hook.on_train_begin()
     return hook
 


### PR DESCRIPTION
### Description of changes:
- The test was written and tested only on TF 2.3.0
- These changes removes this dependency 
```  
    hook.set_mode(ModeKeys.TRAIN)
    hook._prepare_collections()
    hook._increment_step()
``` 
are called in the `on_train_batch_begin` callback for TF 2.2.0 and below.
This test however invokes only `on_train_begin` so I simply execute the required functions so that the test collections are prepared before the start of the test
#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
