### PR TITLE
Pass Variable Length Argument To Old Function Call

### DIFF
--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -339,7 +339,7 @@ def get_layer_call_fn(layer: tf.keras.layers.Layer) -> Callable[[tf.Tensor], tf.
 
     def call(inputs, *args, **kwargs) -> tf.Tensor:
         layer_input = inputs
-        layer_output = old_call_fn(inputs)
+        layer_output = old_call_fn(inputs, *args, **kwargs)
         for hook in layer._hooks:
             hook_result = hook(inputs, layer_input=layer_input, layer_output=layer_output)
             if hook_result is not None:

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -35,8 +35,12 @@ class MyModel(Model):
             x = self.d1(x)
             return self.d2(x)
 
-    def call(self, x, training=None):
+    def call(self, x, training=None, test_input_one=1, test_input_two=2):
         x = self.first(x)
+        # Since we use layer wrapper we need to assert if these parameters
+        # are actually being passed into the original call fn
+        assert test_input_one == 1
+        assert test_input_two == 2
         return self.second(x)
 
 

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -37,7 +37,6 @@ class MyModel(Model):
         with tf.name_scope("first"):
             tf.print("mymodel.first")
             x = self.conv1(x, input_one=1)
-            # x = self.bn(x)
             return self.flatten(x)
 
     def second(self, x):

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -19,7 +19,8 @@ class MyModel(Model):
             # Since we use layer wrapper we need to assert if these parameters
             # are actually being passed into the original call fn
             assert kwargs["input_one"] == 1
-            self.original_call(inputs, *args, **kwargs)
+            kwargs.pop("input_one")
+            return self.original_call(inputs, *args, **kwargs)
 
         self.conv1.call = new_call
         self.conv0 = Conv2D(
@@ -44,10 +45,8 @@ class MyModel(Model):
             x = self.d1(x)
             return self.d2(x)
 
-    def call(self, x, training=None, test_input_one=1, test_input_two=2):
+    def call(self, x, training=None):
         x = self.first(x)
-        assert test_input_one == 1
-        assert test_input_two == 2
         return self.second(x)
 
 


### PR DESCRIPTION
### Description of changes:
- Variable length arguments not passed to `old_fn`

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
