### PR TITLE
Pinning the version of tensorflow_datasets package so that it does not require updating TF

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -30,8 +30,7 @@ phases:
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
-        # tensorflow_datasets verion 4.0.0 and onwards require tensorflow >= 2.1.0
-        - pip install -q pytest==5.3.3 wheel pytest-html pre-commit awscli tensorflow_datasets==3.2.1 pytest-cov
+        - pip install -q pytest==5.3.3 wheel pytest-html pre-commit awscli pytest-cov
 
   pre_build:
     commands:

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -40,6 +40,7 @@ phases:
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR  && python setup.py bdist_wheel --universal
+      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal
       - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --force-reinstall $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
       - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -30,7 +30,7 @@ phases:
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
-        - pip install -q pytest==5.3.3 wheel pytest-html pre-commit awscli pytest-cov
+        - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 
   pre_build:
     commands:

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -30,7 +30,8 @@ phases:
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
-        - pip install -q pytest==5.3.3 wheel pytest-html pre-commit awscli tensorflow_datasets pytest-cov
+        # tensorflow_datasets verion 4.0.0 and onwards require tensorflow >= 2.1.0
+        - pip install -q pytest==5.3.3 wheel pytest-html pre-commit awscli tensorflow_datasets==3.2.1 pytest-cov
 
   pre_build:
     commands:
@@ -39,7 +40,8 @@ phases:
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR  && python setup.py bdist_wheel --universal
-      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl && cd ..
+      # The build container does not have rules binary, we do not need to force-reinstall the binary.
+      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -40,8 +40,7 @@ phases:
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR  && python setup.py bdist_wheel --universal
-      # The build container does not have rules binary, we do not need to force-reinstall the binary.
-      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install dist/*.whl && cd ..
+      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --force-reinstall $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
       - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug

--- a/config/buildspec_build_wheel.yml
+++ b/config/buildspec_build_wheel.yml
@@ -16,7 +16,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit pytest-cov
+        - pip install -q pytest wheel pyYaml pytest-html pre-commit pytest-cov
         - pip uninstall -y boto3 && pip uninstall -y aiobotocore && pip uninstall -y botocore
 
   build:

--- a/config/buildspec_vanilla_framework_tests.yml
+++ b/config/buildspec_vanilla_framework_tests.yml
@@ -18,7 +18,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q pytest==5.3.3 pytest-cov wheel pyYaml pytest-html keras==2.3.1 mxnet torch xgboost pre-commit tensorflow_datasets torchvision
+        - pip install -q pytest pytest-cov wheel pyYaml pytest-html keras==2.3.1 mxnet torch xgboost pre-commit tensorflow_datasets torchvision
         - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:

--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -25,7 +25,8 @@ phases:
       - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
       - pip install --upgrade pip==19.3.1
-      - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit awscli tensorflow_datasets pytest-cov
+      # tensorflow_datasets verion 4.0.0 and onwards require tensorflow >= 2.1.0
+      - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit awscli tensorflow_datasets==3.2.1 pytest-cov
       - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:

--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -25,7 +25,7 @@ phases:
       - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
       - pip install --upgrade pip==19.3.1
-      - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit awscli pytest-cov
+      - pip install -q pytest wheel pyYaml pytest-html pre-commit awscli pytest-cov
       - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:

--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -25,8 +25,7 @@ phases:
       - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
       - pip install --upgrade pip==19.3.1
-      # tensorflow_datasets verion 4.0.0 and onwards require tensorflow >= 2.1.0
-      - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit awscli tensorflow_datasets==3.2.1 pytest-cov
+      - pip install -q pytest==5.3.3 wheel pyYaml pytest-html pre-commit awscli pytest-cov
       - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -60,6 +60,7 @@ if [ "$run_pytest_xgboost" = "enable" ] ; then
 fi
 
 if [ "$run_pytest_tensorflow" = "enable" ] ; then
+    # tensorflow_datasets >= 4.0.0 requires tensorflow >= 2.1.0
     pip install tensorflow_datasets==3.2.1
     run_for_framework tensorflow
 fi

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -60,10 +60,12 @@ if [ "$run_pytest_xgboost" = "enable" ] ; then
 fi
 
 if [ "$run_pytest_tensorflow" = "enable" ] ; then
+    pip install tensorflow_datasets==3.2.1
     run_for_framework tensorflow
 fi
 
 if [ "$run_pytest_tensorflow2" = "enable" ] ; then
+    pip install tensorflow_datasets
     run_for_framework tensorflow2
 fi
 


### PR DESCRIPTION
### Description of changes:
Installing latest version of tensorflow_datasets (post 4.0.0) requires TF version greater than 2.1.0
Which is causing failure in CI that testing with TF 1.15

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
