### PR TITLE
Fixing the nightly build pipelines. Avoid force reinstall of rules package when not necessary

### DIFF
--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -44,7 +44,13 @@ if [ "$SMDEBUG_S3_BINARY" ]; then
   export RULES_COMMIT=`cat s3_pip_binary/RULES_COMMIT`
   echo "Commit hash on sagemaker-debugger-rules repository being used: $RULES_COMMIT"
   cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"
-  python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
+  python setup.py bdist_wheel --universal
+  # on xgboost containers we require rules wheel to be force-reinstalled.
+  if [ "$run_pytest_xgboost" = "enable" ]; then
+    pip install --force-reinstall dist/*.whl
+  else
+    pip install dist/*.whl
+  fi
   echo "Commit hash on sagemaker-debugger repository being used: $CORE_COMMIT"
   cd $CODEBUILD_SRC_DIR && git checkout "$CORE_COMMIT"
   python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
@@ -54,7 +60,13 @@ else
   echo "Commit hash on sagemaker-debugger repository being used: $CORE_COMMIT"
   if [ -z "$RULES_COMMIT" ]; then export RULES_COMMIT=$(git log -1 --pretty=%h); fi
   echo "Commit hash on sagemaker-debugger-rules repository being used: $RULES_COMMIT"
-  cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"  && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
+  cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"  && python setup.py bdist_wheel --universal
+    # on xgboost containers we require rules wheel to be force-reinstalled.
+  if [ "$run_pytest_xgboost" = "enable" ]; then
+    pip install --force-reinstall dist/*.whl
+  else
+    pip install dist/*.whl
+  fi
   cd $CODEBUILD_SRC_DIR && git checkout "$CORE_COMMIT" && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
 fi
 

--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -45,7 +45,7 @@ if [ "$SMDEBUG_S3_BINARY" ]; then
   echo "Commit hash on sagemaker-debugger-rules repository being used: $RULES_COMMIT"
   cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"
   python setup.py bdist_wheel --universal
-  # on xgboost containers we require rules wheel to be force-reinstalled.
+  # on xgboost containers we require rules wheel to be force-reinstalled. Dependencies of rules binary(especially pyYaml) are conflicting with the version on XGBoost container. Force installing the binary seems to be addressing this issue.
   if [ "$run_pytest_xgboost" = "enable" ]; then
     pip install --force-reinstall dist/*.whl
   else
@@ -61,7 +61,7 @@ else
   if [ -z "$RULES_COMMIT" ]; then export RULES_COMMIT=$(git log -1 --pretty=%h); fi
   echo "Commit hash on sagemaker-debugger-rules repository being used: $RULES_COMMIT"
   cd $CODEBUILD_SRC_DIR_RULES && git checkout "$RULES_COMMIT"  && python setup.py bdist_wheel --universal
-    # on xgboost containers we require rules wheel to be force-reinstalled.
+# on xgboost containers we require rules wheel to be force-reinstalled. Dependencies of rules binary(especially pyYaml) are conflicting with the version on XGBoost container. Force installing the binary seems to be addressing this issue.
   if [ "$run_pytest_xgboost" = "enable" ]; then
     pip install --force-reinstall dist/*.whl
   else


### PR DESCRIPTION
### Description of changes:

This is remaining change to fix the nightly builds in the pipeline.
Then script was force reinstalling the rules binary.

Ran the codebuilds for pytorch and xgboost and ensure that they are passing.

pytorch: https://tiny.amazon.com/29lmqkx5/IsenLink
xgboost: https://tiny.amazon.com/o6dpquzv/IsenLink

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
