### PR TITLE
returning list instead of dict keys

### DIFF
--- a/smdebug/rules/action/stop_training_action.py
+++ b/smdebug/rules/action/stop_training_action.py
@@ -79,7 +79,7 @@ class StopTrainingAction:
                 )
                 break
 
-        return found_job_dict.keys()
+        return list(found_job_dict.keys())
 
     def _stop_training_job(self):
         if len(self._found_jobs) != 1:


### PR DESCRIPTION
fix in return of _get_sm_tj_jobs_with_prefix . This function should return list always.


### Description of changes:


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
