### PR TITLE
Add support for mixed precision training

### DIFF
--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -5,6 +5,7 @@ import functools
 import tensorflow.compat.v1 as tf
 from tensorflow.python.distribute import values
 from tensorflow.python.framework.indexed_slices import IndexedSlices
+from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
 from tensorflow.python.util import nest
 
 # First Party
@@ -241,7 +242,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             tensor_refs = []
             for coll in colls_with_tensor:
                 if not tensor_refs:
-                    if isinstance(tensor, tf.Variable):
+                    if isinstance(tensor, (tf.Variable, autocast_variable.AutoCastVariable)):
                         tensor_refs.append(
                             coll.add_variable(tensor, export_name=export_name, mode=mode)
                         )

--- a/smdebug/tensorflow/tensor_ref.py
+++ b/smdebug/tensorflow/tensor_ref.py
@@ -4,19 +4,18 @@ from enum import Enum
 # Third Party
 import tensorflow.compat.v1 as tf
 from tensorflow.python.distribute import values
-from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
 
 # First Party
 from smdebug.core.logger import get_logger
 
 # Local
-from .utils import is_tf_version_2x
+from .utils import is_tf_version_2x, supported_tf_variables
 
 logger = get_logger()
 
 
 def get_tf_names(arg):
-    if isinstance(arg, (tf.Variable, autocast_variable.AutoCastVariable)):
+    if isinstance(arg, supported_tf_variables()):
         tf_names = [arg.name]
     elif isinstance(arg, tf.Tensor):
         tf_names = [arg.name]
@@ -104,7 +103,7 @@ class TensorRef:
             if (
                 is_tf_version_2x()
                 and tf.executing_eagerly()
-                and isinstance(variable, (tf.Variable, autocast_variable.AutoCastVariable))
+                and isinstance(variable, supported_tf_variables())
             ):
                 # In TF 2.X eager mode, TF throws an error if you try to access a tensor's name.
                 # We need to pass it in as a variable, not a tensor, to maintain the name.

--- a/smdebug/tensorflow/tensor_ref.py
+++ b/smdebug/tensorflow/tensor_ref.py
@@ -101,8 +101,6 @@ class TensorRef:
                 # for mirrored variable value this will be the mirrored variable
                 original_tensor = variable
 
-            from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
-
             if (
                 is_tf_version_2x()
                 and tf.executing_eagerly()

--- a/smdebug/tensorflow/tensor_ref.py
+++ b/smdebug/tensorflow/tensor_ref.py
@@ -22,8 +22,9 @@ def get_tf_names(arg):
     elif isinstance(arg, values.DistributedValues):
         tf_names = [v.name for v in arg._values]
     else:
-        print(f"Smdebug currenty does not support:{arg} which of type:{type(arg)}")
-        tf_names = []
+        raise NotImplementedError(
+            f"Smdebug currenty does not support:{arg} which of type:{type(arg)}"
+        )
     return tf_names
 
 

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -14,7 +14,7 @@ from smdebug.core.modes import ModeKeys
 
 
 def does_tf_support_mixed_precision_training():
-    # The Keras mixed precision API is available starting TensorFlow 2.1.
+    # The Keras mixed precision API is first available in TensorFlow 2.1.0
     # See: https://www.tensorflow.org/guide/mixed_precision
     return version.parse(tf.__version__) >= version.parse("2.1.0")
 

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -13,6 +13,21 @@ from tensorflow.python.distribute import values
 from smdebug.core.modes import ModeKeys
 
 
+def does_tf_support_mixed_precision_training():
+    # The Keras mixed precision API is available starting TensorFlow 2.1.
+    # See: https://www.tensorflow.org/guide/mixed_precision
+    return version.parse(tf.__version__) >= version.parse("2.1.0")
+
+
+def supported_tf_variables():
+    if does_tf_support_mixed_precision_training():
+        from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
+
+        return tf.Variable, autocast_variable.AutoCastVariable
+    else:
+        return tf.Variable
+
+
 class ModelOutput:
     LABELS = "smdebug_y"
     PREDICTIONS = "smdebug_y_pred"

--- a/tests/tensorflow2/test_mixed_precision_training.py
+++ b/tests/tensorflow2/test_mixed_precision_training.py
@@ -1,0 +1,61 @@
+# Third Party
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras.mixed_precision import experimental as mixed_precision
+
+# First Party
+import smdebug.tensorflow as smd
+from smdebug.trials import create_trial
+
+# Test Reference: https://github.com/tensorflow/docs/blob/master/site/en/guide/mixed_precision.ipynb
+
+
+def test_mixed_precision_training(out_dir):
+    hook = smd.KerasHook(out_dir=out_dir, save_all=True)
+    policy = mixed_precision.Policy("mixed_float16")
+    mixed_precision.set_policy(policy)
+
+    inputs = keras.Input(shape=(784,), name="digits")
+    if tf.config.list_physical_devices("GPU"):
+        # The model will run with 4096 units on a GPU
+        num_units = 4096
+    else:
+        # Use fewer units on CPUs so the model finishes in a reasonable amount of time
+        # The model will run with 64 units on a CPU
+        num_units = 64
+    dense1 = layers.Dense(num_units, activation="relu", name="dense_1")
+    x = dense1(inputs)
+    dense2 = layers.Dense(num_units, activation="relu", name="dense_2")
+    x = dense2(x)
+
+    # CORRECT: softmax and model output are float32
+    x = layers.Dense(10, name="dense_logits")(x)
+    outputs = layers.Activation("softmax", dtype="float32", name="predictions")(x)
+
+    # The linear activation is an identity function. So this simply casts 'outputs'
+    # to float32. In this particular case, 'outputs' is already float32 so this is a
+    # no-op.
+    outputs = layers.Activation("linear", dtype="float32")(outputs)
+
+    model = keras.Model(inputs=inputs, outputs=outputs)
+    model.compile(
+        loss="sparse_categorical_crossentropy",
+        optimizer=keras.optimizers.RMSprop(),
+        metrics=["accuracy"],
+    )
+
+    (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+    x_train = x_train.reshape(60000, 784).astype("float32") / 255
+    x_test = x_test.reshape(10000, 784).astype("float32") / 255
+
+    initial_weights = model.get_weights()
+
+    hooks = [hook]
+    history = model.fit(
+        x_train, y_train, batch_size=8192, epochs=5, callbacks=hooks, validation_split=0.2
+    )
+    test_scores = model.evaluate(x_test, y_test, verbose=2)
+
+    trial = create_trial(out_dir)
+    assert len(trial.tensor_names()) == 30

--- a/tests/tensorflow2/test_mixed_precision_training.py
+++ b/tests/tensorflow2/test_mixed_precision_training.py
@@ -1,17 +1,22 @@
 # Third Party
+import pytest
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
-from tensorflow.keras.mixed_precision import experimental as mixed_precision
 
 # First Party
 import smdebug.tensorflow as smd
+from smdebug.tensorflow.utils import does_tf_support_mixed_precision_training
 from smdebug.trials import create_trial
 
 # Test Reference: https://github.com/tensorflow/docs/blob/master/site/en/guide/mixed_precision.ipynb
 
 
+@pytest.mark.skipif(does_tf_support_mixed_precision_training() is False)
 def test_mixed_precision_training(out_dir):
+
+    from tensorflow.keras.mixed_precision import experimental as mixed_precision
+
     hook = smd.KerasHook(out_dir=out_dir, save_all=True)
     policy = mixed_precision.Policy("mixed_float16")
     mixed_precision.set_policy(policy)

--- a/tests/tensorflow2/test_mixed_precision_training.py
+++ b/tests/tensorflow2/test_mixed_precision_training.py
@@ -12,7 +12,10 @@ from smdebug.trials import create_trial
 # Test Reference: https://github.com/tensorflow/docs/blob/master/site/en/guide/mixed_precision.ipynb
 
 
-@pytest.mark.skipif(does_tf_support_mixed_precision_training() is False)
+@pytest.mark.skipif(
+    does_tf_support_mixed_precision_training() is False,
+    reason="The Keras mixed precision API is first available in TensorFlow 2.1.0",
+)
 def test_mixed_precision_training(out_dir):
 
     from tensorflow.keras.mixed_precision import experimental as mixed_precision


### PR DESCRIPTION
### Description of changes:
- Add support for Autocast variables that are created when mixed precision training is enabled.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
