### PR TITLE
Temporary Change To The Pytorch ZCC Tests

### DIFF
--- a/tests/zero_code_change/pt_utils.py
+++ b/tests/zero_code_change/pt_utils.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 import torchvision.transforms as transforms
+from packaging import version
 
 
 def get_dataloaders() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader]:
@@ -14,15 +15,26 @@ def get_dataloaders() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.Dat
         [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
     )
 
+    # Temporary Change to allow the test to run with pytorch 1.7 RC3
+    # Smdebug breaks when num_workers>0 for Pytorch 1.7.0
+    if version.parse(torch.__version__) >= version.parse("1.7.0"):
+        num_workers = 0
+    else:
+        num_workers = 2
+
     trainset = torchvision.datasets.CIFAR10(
         root="./data", train=True, download=True, transform=transform
     )
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4, shuffle=True, num_workers=2)
+    trainloader = torch.utils.data.DataLoader(
+        trainset, batch_size=4, shuffle=True, num_workers=num_workers
+    )
 
     testset = torchvision.datasets.CIFAR10(
         root="./data", train=False, download=True, transform=transform
     )
-    testloader = torch.utils.data.DataLoader(testset, batch_size=4, shuffle=False, num_workers=2)
+    testloader = torch.utils.data.DataLoader(
+        testset, batch_size=4, shuffle=False, num_workers=num_workers
+    )
 
     classes = ("plane", "car", "bird", "cat", "deer", "dog", "frog", "horse", "ship", "truck")
     return trainloader, testloader


### PR DESCRIPTION
### Description of changes:
- Pytorch ZCC tests currently fail with the pytorch 1.7 RC build when the  num_workers>0 in the dataloader.
- This fix unblocks pytorch 1.7 pipelines, while we root cause and fix the issue long term.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
