### PR TITLE
Extend Gradtape ZCC to 2.1.2

### DIFF
--- a/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
@@ -12,7 +12,8 @@ import argparse
 # Third Party
 import pytest
 import tensorflow.compat.v2 as tf
-from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3
+from packaging import version
+from tests.tensorflow2.utils import is_tf_2_2
 
 # First Party
 import smdebug.tensorflow as smd
@@ -104,8 +105,8 @@ def helper_test_keras_v2_gradienttape(
                 print(log)
                 train_acc_metric.reset_states()
             hook = smd.get_hook()
-            if not (is_tf_2_2() or is_tf_2_3()):
-                assert not hook  # only supported on TF 2.2 and greater
+            if version.parse(tf.__version__) < version.parse("2.1.2"):
+                assert not hook  # only supported on TF 2.1.2 and greater
                 return
             assert hook
             hook.close()


### PR DESCRIPTION
### Description of changes:
- Gradient tape ZCC features were backported into AWS TF 2.1.2
- Updating the test to reflect this change.


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
