### PR TITLE
Disable ZCC Tests for Pytorch 1.7

### DIFF
--- a/tests/zero_code_change/test_pytorch_integration.py
+++ b/tests/zero_code_change/test_pytorch_integration.py
@@ -12,6 +12,7 @@ import argparse
 
 # Third Party
 import pytest
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
@@ -22,6 +23,10 @@ import smdebug.pytorch as smd
 from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 
 
+@pytest.mark.skipif(
+    torch.__version__ == "1.7.0",
+    reason="Disabling the test temporarily until we root cause the version incompatibility",
+)
 @pytest.mark.parametrize("script_mode", [False])
 @pytest.mark.parametrize("use_loss_module", [True, False])
 def test_pytorch(script_mode, use_loss_module):


### PR DESCRIPTION
### Description of changes:
- The hook does not save tensors with pytorch 1.7
- Disabing the test for pytoch 1.7 until we root cause the issue

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
