### PR TITLE
[WIP]Use get_name in forward hook

### DIFF
--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -3,6 +3,7 @@
 # Third Party
 import torch
 import torch.distributed as dist
+from torch.nn.parallel.data_parallel import DataParallel
 
 # First Party
 from smdebug.core.collection import DEFAULT_PYTORCH_COLLECTIONS, CollectionKeys
@@ -199,7 +200,7 @@ class Hook(CallbackHook):
 
     @staticmethod
     def _add_module_name(module, module_name):
-        if isinstance(module, torch.nn.parallel.data_parallel.DataParallel):
+        if isinstance(module, DataParallel):
             module.module._module_name = module_name
         else:
             module._module_name = module_name

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -197,6 +197,14 @@ class Hook(CallbackHook):
         # for compatibility with ZCC patches which call this
         self.register_module(module)
 
+    @staticmethod
+    def _add_module_name(module, module_name):
+        if isinstance(module, torch.nn.parallel.data_parallel.DataParallel):
+            module.module._module_name = module_name
+        else:
+            module._module_name = module_name
+        return module
+
     def register_module(self, module):
         """
         This function registers the forward hook. If user wants to register the hook
@@ -215,9 +223,9 @@ class Hook(CallbackHook):
 
         for name, submodule in module.named_modules():
             assert submodule not in self.module_set, f"Don't register module={module} twice"
-            submodule._module_name = name
+            Hook._add_module_name(submodule, name)
             self.module_set.add(submodule)
-        module._module_name = module._get_name()
+        Hook._add_module_name(module, module._get_name())
         self.module_set.add(module)
 
         # Use `forward_pre_hook` for the entire net


### PR DESCRIPTION
### Description of bug:
- Users can wrap their modules with helper classes like `DataParallelCriterion` or `DataParallel`
```
custom_loss_module = CustomLossModule()
parallel_custom_loss_module = DataParallelCriterion(custom_loss_module)
```
- The smdebug hook register each module like this:
```
        for name, submodule in module.named_modules():
            assert submodule not in self.module_set, f"Don't register module={module} twice"
            submodule._module_name = name
            self.module_set.add(submodule)
        module._module_name = module._get_name()
        self.module_set.add(module)
```

The problem with the above line is that the `_module_name` attribute is attached to the `parallel_custom_loss_module` and not the nested `custom_loss_module`.

- We would have instead needed to do:
```
submodule.module._module_name = name
```
- When the call to the forward hook is made, the helper module will internally call:
```
    def forward(self, *inputs, **kwargs):
        if not self.device_ids:
            return self.module(*inputs, **kwargs)
```

We should instead simply use:
`module._get_name()` in the `forward_hook` 





#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
