### PR TITLE
Attempting to fix the flaky test for multiprocessing

### DIFF
--- a/config/buildspec_vanilla_framework_tests.yml
+++ b/config/buildspec_vanilla_framework_tests.yml
@@ -20,7 +20,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q pytest pytest-cov wheel pyYaml pytest-html keras==2.3.1 mxnet torch xgboost pre-commit tensorflow_datasets==4.0.1 torchvision
+        - pip install -q -U pytest pytest-cov wheel pyYaml pytest-html keras==2.3.1 mxnet torch xgboost pre-commit tensorflow_datasets==4.0.1 torchvision
         - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
 
   build:

--- a/config/install_smdebug.sh
+++ b/config/install_smdebug.sh
@@ -51,7 +51,7 @@ if [ "$SMDEBUG_S3_BINARY" ]; then
   fi
   echo "Commit hash on sagemaker-debugger repository being used: $CORE_COMMIT"
   cd $CODEBUILD_SRC_DIR && git checkout "$CORE_COMMIT"
-  python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
+  python setup.py bdist_wheel --universal && pip install -U dist/*.whl
 else
   # if the env var stable_release is not set, then this else block is executed.
   if [ -z "$CORE_COMMIT" ]; then export CORE_COMMIT=$(git log -1 --pretty=%h); fi
@@ -65,7 +65,7 @@ else
   else
     pip install dist/*.whl
   fi
-  cd $CODEBUILD_SRC_DIR && git checkout "$CORE_COMMIT" && python setup.py bdist_wheel --universal && pip install --force-reinstall dist/*.whl
+  cd $CODEBUILD_SRC_DIR && git checkout "$CORE_COMMIT" && python setup.py bdist_wheel --universal && pip install -U dist/*.whl
 fi
 
 if [ "$run_pytest_mxnet" == 'enable' ]; then


### PR DESCRIPTION
### Description of changes:
The test has 2 issues:
1.  It downloads the data from internet.
2.  The 2 processes spun off during the training are downloading the mnist data to the same folder.

The change pre-downloads the data from s3 bucket. Both the processes can refer to the same data without downloading it themselves.

Similarly, the vanilla buildspec attempts to install framework but it never upgrades it.

The force reinstall of wheels on container is unnecessary they are causing flaky failures in pipelines with following errors:

ERROR: Cannot uninstall 'ipython-genutils'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.

### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
