### PR TITLE
Fix mixed precision import bug for TF 2.4.x

### DIFF
--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -22,7 +22,10 @@ def does_tf_support_mixed_precision_training():
 
 def supported_tf_variables():
     if does_tf_support_mixed_precision_training():
-        from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
+        if is_tf_version_2_4_x():
+            from tensorflow.python.keras.mixed_precision import autocast_variable
+        else:
+            from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
 
         return tf_v1.Variable, autocast_variable.AutoCastVariable
     else:
@@ -409,6 +412,10 @@ def is_tf_version_2_2_x():
 
 def is_tf_version_2_3_x():
     return version.parse("2.3.0") <= version.parse(tf.__version__) < version.parse("2.4.0")
+
+
+def is_tf_version_2_4_x():
+    return version.parse("2.4.0") <= version.parse(tf.__version__) < version.parse("2.5.0")
 
 
 def is_profiler_supported_for_tf_version():

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -21,8 +21,15 @@ def does_tf_support_mixed_precision_training():
 
 
 def supported_tf_variables():
+    def is_mixed_precision_api_experimental():
+        """
+        tensorflow mixed preicison api is experimental in versions below 2.4.0
+        :return: bool
+        """
+        return version.parse("2.4.0") <= version.parse(tf.__version__)
+
     if does_tf_support_mixed_precision_training():
-        if is_tf_version_2_4_x():
+        if is_mixed_precision_api_experimental():
             from tensorflow.python.keras.mixed_precision import autocast_variable
         else:
             from tensorflow.python.keras.mixed_precision.experimental import autocast_variable

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -26,13 +26,13 @@ def supported_tf_variables():
         tensorflow mixed preicison api is experimental in versions below 2.4.0
         :return: bool
         """
-        return version.parse("2.4.0") <= version.parse(tf.__version__)
+        return version.parse(tf.__version__) < version.parse("2.4.0")
 
     if does_tf_support_mixed_precision_training():
         if is_mixed_precision_api_experimental():
-            from tensorflow.python.keras.mixed_precision import autocast_variable
-        else:
             from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
+        else:
+            from tensorflow.python.keras.mixed_precision import autocast_variable
 
         return tf_v1.Variable, autocast_variable.AutoCastVariable
     else:


### PR DESCRIPTION
### Description of changes:
In TensorFlow 2.4, the Keras mixed precision API has moved out of experimental and is now a stable API. As a result, we need to use a different import if the user is using TF 2.4.x

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
