### PR TITLE
Fix flaky timeline writer test

### DIFF
--- a/config/tests.sh
+++ b/config/tests.sh
@@ -58,9 +58,9 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+#python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
-run_for_framework core
+#run_for_framework core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost
@@ -83,8 +83,9 @@ if [ "$run_pytest_mxnet" = "enable" ] ; then
 fi
 
 if [ "$run_pytest_pytorch" = "enable" ] ; then
-    run_for_framework pytorch
-    run_profiler_test pytorch
+  python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/core/test_timeline_writer.py::test_utc_timestamp
+#    run_for_framework pytorch
+#    run_profiler_test pytorch
 fi
 
 check_logs $REPORT_DIR/*

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -58,9 +58,9 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-#python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
-#run_for_framework core
+run_for_framework core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost
@@ -83,9 +83,8 @@ if [ "$run_pytest_mxnet" = "enable" ] ; then
 fi
 
 if [ "$run_pytest_pytorch" = "enable" ] ; then
-  python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/core/test_timeline_writer.py::test_utc_timestamp
-#    run_for_framework pytorch
-#    run_profiler_test pytorch
+    run_for_framework pytorch
+    run_profiler_test pytorch
 fi
 
 check_logs $REPORT_DIR/*

--- a/tests/core/test_timeline_writer.py
+++ b/tests/core/test_timeline_writer.py
@@ -278,7 +278,7 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
 
     time.tzset()
     event_time_in_timezone = time.mktime(time.localtime())
-    time_in_utc = event_time_in_utc = calendar.timegm(time.gmtime())
+    event_time_in_utc = calendar.timegm(time.gmtime())
 
     timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
     assert timeline_writer
@@ -295,6 +295,7 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
         event_time_in_timezone = time.mktime(time.localtime())
         event_time_in_utc = calendar.timegm(time.gmtime())
 
+    time_in_utc = calendar.timegm(time.gmtime())
     timeline_writer.flush()
     timeline_writer.close()
 
@@ -302,11 +303,11 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
     for path in Path(out_dir + "/" + DEFAULT_PREFIX).rglob("*.json"):
         files.append(path)
 
-    file_path = sorted(files)[0]
+    file_path = files[0]
     path = file_path.name.split(DEFAULT_PREFIX)
     file_timestamp = int(path[0].split("_")[0])
 
-    # file timestamp uses end of event
+    # file timestamp uses end of last event
     assert (time_in_utc + 20) * CONVERT_TO_MICROSECS == file_timestamp
 
     start_time_since_epoch = 0

--- a/tests/core/test_timeline_writer.py
+++ b/tests/core/test_timeline_writer.py
@@ -277,14 +277,14 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
     assert simple_profiler_config_parser.profiling_enabled
 
     time.tzset()
-    event_time_in_timezone = time.mktime(time.localtime())
-    event_time_in_utc = calendar.timegm(time.gmtime())
 
     timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
     assert timeline_writer
 
     event_times_in_utc = []
     for i in range(1, 3):
+        event_time_in_timezone = time.mktime(time.localtime())
+        event_time_in_utc = time_in_utc = calendar.timegm(time.gmtime())
         event_times_in_utc.append(event_time_in_utc)
         timeline_writer.write_trace_events(
             training_phase=f"TimestampTest",
@@ -292,10 +292,7 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
             timestamp=event_time_in_timezone,
             duration=20,
         )
-        event_time_in_timezone = time.mktime(time.localtime())
-        event_time_in_utc = calendar.timegm(time.gmtime())
 
-    time_in_utc = calendar.timegm(time.gmtime())
     timeline_writer.flush()
     timeline_writer.close()
 

--- a/tests/core/test_timeline_writer.py
+++ b/tests/core/test_timeline_writer.py
@@ -268,11 +268,12 @@ def test_rotation_policy(rotation_profiler_config_parser, policy, out_dir):
 
 
 @pytest.mark.parametrize("timezone", ["Europe/Dublin", "Australia/Melbourne", "US/Eastern"])
-def test_utc_timestamp(simple_profiler_config_parser, timezone, out_dir):
+def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out_dir):
     """
     This test is meant to set to create files/events in different timezones and check if timeline writer stores
     them in UTC.
     """
+    monkeypatch.setenv("TZ", timezone)
     assert simple_profiler_config_parser.profiling_enabled
 
     timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)

--- a/tests/core/test_timeline_writer.py
+++ b/tests/core/test_timeline_writer.py
@@ -275,12 +275,12 @@ def test_utc_timestamp(simple_profiler_config_parser, timezone, out_dir):
     """
     assert simple_profiler_config_parser.profiling_enabled
 
+    timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
+    assert timeline_writer
+
     time.tzset()
     event_time_in_timezone = time.mktime(time.localtime())
     time_in_utc = event_time_in_utc = calendar.timegm(time.gmtime())
-
-    timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
-    assert timeline_writer
 
     event_times_in_utc = []
     for i in range(1, 3):

--- a/tests/core/test_timeline_writer.py
+++ b/tests/core/test_timeline_writer.py
@@ -276,12 +276,12 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
     monkeypatch.setenv("TZ", timezone)
     assert simple_profiler_config_parser.profiling_enabled
 
-    timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
-    assert timeline_writer
-
     time.tzset()
     event_time_in_timezone = time.mktime(time.localtime())
     time_in_utc = event_time_in_utc = calendar.timegm(time.gmtime())
+
+    timeline_writer = TimelineFileWriter(profiler_config_parser=simple_profiler_config_parser)
+    assert timeline_writer
 
     event_times_in_utc = []
     for i in range(1, 3):
@@ -302,7 +302,7 @@ def test_utc_timestamp(monkeypatch, simple_profiler_config_parser, timezone, out
     for path in Path(out_dir + "/" + DEFAULT_PREFIX).rglob("*.json"):
         files.append(path)
 
-    file_path = files[0]
+    file_path = sorted(files)[0]
     path = file_path.name.split(DEFAULT_PREFIX)
     file_timestamp = int(path[0].split("_")[0])
 


### PR DESCRIPTION
### Description of changes:
Refactored the `test_utc_timestamp` timeline writer test. The key differences:
- `time_in_utc` is redefined whenever `event_time_in_timezone` is redefined and used for writing an event
- `timezone` is now actually used to generate the timestamps that are tested

Without these changes, the test sometimes fails due to a one second difference between `time_in_utc + 20` and the trace file's timestamp. This occurs because the file timestamp reflects the end time of the last event, so there would sometimes be a one second difference between where `time_in_utc` is currently defined and where the last event time (`event_time_in_timezone`) is defined. These changes serve to fix this flaky behavior.

Tested this change by running only the `test_utc_timestamp` test in the PT build. Without this change, the test always fails, but with this change, the test always passes (repeated 5 times each).
  
#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
