### PR TITLE
Fixing the codebuild project for xgboost.

### DIFF
--- a/config/buildspec_zero_code_change.yml
+++ b/config/buildspec_zero_code_change.yml
@@ -21,6 +21,8 @@ env:
 phases:
   install:
     commands:
+      # The recent update to XGBoost container is requiring to update the PUB_KEY for successfully running the apt-get update
+      - if [ "$run_pytest_xgboost" = "enable" ]; then su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D; fi
       - apt-get update
       - apt-get install sudo -qq -o=Dpkg::Use-Pty=0
       - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0


### PR DESCRIPTION
### Description of changes:
The XGboost codebuild project started failing with following error.  The change registers the PUBKEY to avoid this failure.


```

Err:2 https://apt.kitware.com/ubuntu bionic InRelease
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY DE19EB17684BA42D



W: GPG error: https://apt.kitware.com/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY DE19EB17684BA42D
--



```

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
