### PR TITLE
Modify distributed_training_utils.py import for TF 2.4

### DIFF
--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -48,6 +48,7 @@ from .utils import (
     is_profiler_supported_for_tf_version,
     is_tf_version_2_3_x,
     is_tf_version_2x,
+    is_tf_version_greater_than_2_4_x,
     supported_tf_variables,
 )
 
@@ -139,9 +140,16 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                 self._hook_supported = False
             elif self.distribution_strategy == TFDistributionStrategy.MIRRORED:
                 try:
-                    from tensorflow.python.keras.distribute.distributed_training_utils import (
-                        get_distributed_model,
-                    )
+                    if is_tf_version_greater_than_2_4_x():
+                        # distributed_training_utils.py renamed to distributed_training_utils_v1 in tf 2.4.0
+                        from tensorflow.python.keras.distribute.distributed_training_utils_v1 import (
+                            get_distributed_model,
+                        )
+                    else:
+                        from tensorflow.python.keras.distribute.distributed_training_utils import (
+                            get_distributed_model,
+                        )
+
                 except ImportError:
                     # for tf1.13 we can't import this, so we can't support mirrored strategy
                     self.logger.info(

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -21,18 +21,13 @@ def does_tf_support_mixed_precision_training():
 
 
 def supported_tf_variables():
-    def is_mixed_precision_api_experimental():
-        """
-        tensorflow mixed preicison api is experimental in versions below 2.4.0
-        :return: bool
-        """
-        return version.parse(tf.__version__) < version.parse("2.4.0")
-
     if does_tf_support_mixed_precision_training():
-        if is_mixed_precision_api_experimental():
-            from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
-        else:
+        if is_tf_version_greater_than_2_4_x():
+            # tensorflow mixed preicison api is experimental in versions below 2.4.0
             from tensorflow.python.keras.mixed_precision import autocast_variable
+
+        else:
+            from tensorflow.python.keras.mixed_precision.experimental import autocast_variable
 
         return tf_v1.Variable, autocast_variable.AutoCastVariable
     else:

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -425,5 +425,9 @@ def is_tf_version_2_4_x():
     return version.parse("2.4.0") <= version.parse(tf.__version__) < version.parse("2.5.0")
 
 
+def is_tf_version_greater_than_2_4_x():
+    return version.parse("2.4.0") <= version.parse(tf.__version__)
+
+
 def is_profiler_supported_for_tf_version():
     return is_tf_version_2_2_x() or is_tf_version_2_3_x()


### PR DESCRIPTION
### Description of changes:
- The distributed_training_utils.py has been renamed to distributed_training_utils_v1.py in TF 2.4


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
