### PR TITLE
Refactor profiler config parser tests

### DIFF
--- a/tests/profiler/core/test_profiler_config_parser.py
+++ b/tests/profiler/core/test_profiler_config_parser.py
@@ -6,11 +6,11 @@ import time
 # Third Party
 import pytest
 from tests.profiler.resources.profiler_config_parser_utils import (
+    build_metrics_config,
     current_step,
     current_time,
     dataloader_test_cases,
     detailed_profiling_test_cases,
-    form_config,
     python_profiling_test_cases,
     smdataparallel_profiling_test_cases,
 )
@@ -100,7 +100,7 @@ def new_time_profiler_config_parser_path(config_folder):
 def test_detailed_profiling_ranges(profiler_config_path, test_case):
     profiling_parameters, expected_enabled, expected_can_save, expected_values = test_case
     start_step, num_steps, start_time, duration = profiling_parameters
-    detailed_profiling_config = form_config(
+    detailed_profiling_config = build_metrics_config(
         StartStep=start_step,
         NumSteps=num_steps,
         StartTimeInSecSinceEpoch=start_time,
@@ -140,7 +140,9 @@ def test_detailed_profiling_ranges(profiler_config_path, test_case):
 def test_dataloader_profiling_ranges(profiler_config_path, test_case):
     profiling_parameters, expected_enabled, expected_can_save, expected_values = test_case
     start_step, metrics_regex, metrics_name = profiling_parameters
-    dataloader_profiling_config = form_config(StartStep=start_step, MetricsRegex=metrics_regex)
+    dataloader_profiling_config = build_metrics_config(
+        StartStep=start_step, MetricsRegex=metrics_regex
+    )
 
     full_config = {
         "ProfilingParameters": {
@@ -174,7 +176,7 @@ def test_dataloader_profiling_ranges(profiler_config_path, test_case):
 def test_python_profiling_ranges(profiler_config_path, test_case):
     profiling_parameters, expected_enabled, expected_can_save, expected_values = test_case
     start_step, num_steps, profiler_name, cprofile_timer = profiling_parameters
-    python_profiling_config = form_config(
+    python_profiling_config = build_metrics_config(
         StartStep=start_step,
         NumSteps=num_steps,
         ProfilerName=profiler_name,
@@ -215,7 +217,7 @@ def test_smdataparallel_profiling_ranges(profiler_config_path, test_case):
     profiling_parameters, expected_enabled, expected_can_save, expected_values = test_case
     start_step, num_steps = profiling_parameters
 
-    smdataparallel_profiling_config = form_config(StartStep=start_step, NumSteps=num_steps)
+    smdataparallel_profiling_config = build_metrics_config(StartStep=start_step, NumSteps=num_steps)
 
     full_config = {
         "ProfilingParameters": {

--- a/tests/profiler/resources/profiler_config_parser_utils.py
+++ b/tests/profiler/resources/profiler_config_parser_utils.py
@@ -256,3 +256,7 @@ smdataparallel_profiling_test_cases = [
         (bad_start_step_2, bad_start_step_2 + PROFILING_NUM_STEPS_DEFAULT),
     ),
 ]
+
+
+def form_config(**config_parameters):
+    return str({key: value for key, value in config_parameters.items() if value is not None})

--- a/tests/profiler/resources/profiler_config_parser_utils.py
+++ b/tests/profiler/resources/profiler_config_parser_utils.py
@@ -258,5 +258,5 @@ smdataparallel_profiling_test_cases = [
 ]
 
 
-def form_config(**config_parameters):
+def build_metrics_config(**config_parameters):
     return str({key: value for key, value in config_parameters.items() if value is not None})


### PR DESCRIPTION
### Description of changes:
Refactor profiler config parser tests in two ways:
- Use only one fixture for the profiling ranges tests since the profiler config is generated dynamically for those tests anyways
- Simply call `str` after forming the profiler config for these profiling instead of forming the string dynamically.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
