### PR TITLE
Use codebuild env variable to get current branch in profiler integration tests

### DIFF
--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -5,8 +5,9 @@
 echo "Start profiler integration tests script."
 
 echo "base ref" $CODEBUILD_WEBHOOK_BASE_REF
+echo $(git diff --name-only master $CODEBUILD_WEBHOOK_BASE_REF 2>/dev/null)
 
-CODEBUILD_GIT_BRANCH=$(git branch | grep '^*' | sed 's/* //' )
+CODEBUILD_GIT_BRANCH$(git branch -q -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)
 echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -2,6 +2,8 @@
 
 # To manually disable profiler integration tests from running in the PR CI, set this environment variable to "true".
 # If you do this, remember to reset it back to "false" before merging the PR.
+echo "Start profiler integration tests script."
+
 disable_integration_tests="false"
 if [ $disable_integration_tests = "true" ]
 then

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-disable_integration_tests="false"
+disable_integration_tests="true"
 if [ $disable_integration_tests = "true" ]
 then
   echo "PROFILER INTEGRATION TESTS MANUALLY DISABLED!"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-CODEBUILD_GIT_BRANCH="$(git symbolic-ref --short -q HEAD)"
+CODEBUILD_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-CODEBUILD_GIT_BRANCH=$(git describe --contains --all HEAD);
+CODEBUILD_GIT_BRANCH="$(git describe --contains --all HEAD)"
 
 disable_integration_tests="true"
 if [ $disable_integration_tests = "true" ]

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -46,7 +46,6 @@ check_changed_files() {
 # If we are not force running the tests, determine whether to run the tests based on the files changed in the branch compared to master.
 run_tests="true"
 if [ $force_run_tests = "false" ]; then
-  echo "Running check changed files"
   run_tests=$( check_changed_files )
 fi
 
@@ -71,7 +70,6 @@ then
   aws s3 cp s3://smdebug-testing/datasets/cifar-10-python.tar.gz data/cifar-10-batches-py.tar.gz >/dev/null 2>/dev/null # mask output
   aws s3 cp s3://smdebug-testing/datasets/MNIST_pytorch.tar.gz data/MNIST_pytorch.tar.gz >/dev/null 2>/dev/null # mask output
   cd $CODEBUILD_SRC_DIR_TESTS/tests/scripts/pytorch_scripts/data
-  cd data
   tar -zxf MNIST_pytorch.tar.gz >/dev/null 2>/dev/null # mask output
   tar -zxf cifar-10-batches-py.tar.gz >/dev/null 2>/dev/null # mask output
 else

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-CODEBUILD_GIT_BRANCH="$(git describe --contains --all HEAD)"
+CODEBUILD_GIT_BRANCH="$(git symbolic-ref --short -q HEAD)"
 
 disable_integration_tests="true"
 if [ $disable_integration_tests = "true" ]

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -5,9 +5,7 @@
 echo "Start profiler integration tests script."
 
 echo "base ref" $CODEBUILD_WEBHOOK_HEAD_REF
-echo $(git diff --name-only master $CODEBUILD_WEBHOOK_BASE_REF 2>/dev/null)
-
-CODEBUILD_GIT_BRANCH$(git branch -q -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)
+CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#remotes/origin/}
 echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-CODEBUILD_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+CODEBUILD_GIT_BRANCH=$(git branch | grep '^*' | sed 's/* //' )
 echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,6 +4,8 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
+echo "base ref" $CODEBUILD_WEBHOOK_BASE_REF
+
 CODEBUILD_GIT_BRANCH=$(git branch | grep '^*' | sed 's/* //' )
 echo $CODEBUILD_GIT_BRANCH
 

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -7,7 +7,7 @@ echo "Start profiler integration tests script."
 export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
 echo "Finished git command 1"
 if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-  CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)";
+  CODEBUILD_GIT_BRANCH=$(git describe --contains --all HEAD);
   export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
 fi
 echo "Finished git command 2"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -5,6 +5,7 @@
 echo "Start profiler integration tests script."
 
 CODEBUILD_GIT_BRANCH="$(git symbolic-ref --short -q HEAD)"
+echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"
 if [ $disable_integration_tests = "true" ]

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,7 +4,7 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-echo "base ref" $CODEBUILD_WEBHOOK_BASE_REF
+echo "base ref" $CODEBUILD_WEBHOOK_HEAD_REF
 echo $(git diff --name-only master $CODEBUILD_WEBHOOK_BASE_REF 2>/dev/null)
 
 CODEBUILD_GIT_BRANCH$(git branch -q -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,13 +4,6 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-disable_integration_tests="true"
-if [ $disable_integration_tests = "true" ]
-then
-  echo "PROFILER INTEGRATION TESTS MANUALLY DISABLED!"
-  exit 0
-fi
-
 check_changed_files() {
   # Get the branch we're running integration tests on.
   export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
@@ -52,7 +45,15 @@ check_changed_files() {
 # If we are not force running the tests, determine whether to run the tests based on the files changed in the branch compared to master.
 run_tests="true"
 if [ $force_run_tests = "false" ]; then
+  echo "Running check changed files"
   run_tests=$( check_changed_files )
+fi
+
+disable_integration_tests="true"
+if [ $disable_integration_tests = "true" ]
+then
+  echo "PROFILER INTEGRATION TESTS MANUALLY DISABLED!"
+  exit 0
 fi
 
 apt-get update >/dev/null 2>/dev/null # mask output

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,8 +4,6 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-sleep 1m
-
 CODEBUILD_GIT_BRANCH=$(git describe --contains --all HEAD);
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -13,7 +13,7 @@ check_changed_files() {
   # Get the branch we're running integration tests on.
   export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
   if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-    CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }')";
+    CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)";
     export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
   fi
 
@@ -25,7 +25,7 @@ check_changed_files() {
 
   # Otherwise, check to see what files have changed in this branch. If files in smdebug/core or smdebug/profiler or
   # smdebug/$framework have been modified, run the integration tests. Otherwise, don't run the integration tests.
-  for file in $(git diff --name-only master $CODEBUILD_GIT_BRANCH)
+  for file in $(git diff --name-only master $CODEBUILD_GIT_BRANCH 2>/dev/null)
   do
     root_folder=$(echo $file | cut -d/ -f 1)
     framework_folder=$(echo $file | cut -d/ -f 2)

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -5,7 +5,7 @@
 echo "Start profiler integration tests script."
 
 echo "base ref" $CODEBUILD_WEBHOOK_HEAD_REF
-CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#remotes/origin/}
+CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/}
 echo $CODEBUILD_GIT_BRANCH
 
 disable_integration_tests="true"

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -4,43 +4,9 @@
 # If you do this, remember to reset it back to "false" before merging the PR.
 echo "Start profiler integration tests script."
 
-export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
-echo "Finished git command 1"
-if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-  CODEBUILD_GIT_BRANCH=$(git describe --contains --all HEAD);
-  export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
-fi
-echo "Finished git command 2"
+sleep 1m
 
-# If the branch is master, then just run integration tests.
-if [ $CODEBUILD_GIT_BRANCH = "master" ]; then
-  echo "true"
-#  return
-fi
-
-# Otherwise, check to see what files have changed in this branch. If files in smdebug/core or smdebug/profiler or
-# smdebug/$framework have been modified, run the integration tests. Otherwise, don't run the integration tests.
-for file in $(git diff --name-only master $CODEBUILD_GIT_BRANCH 2>/dev/null)
-do
-  echo "Finished git command 3"
-  root_folder=$(echo $file | cut -d/ -f 1)
-  framework_folder=$(echo $file | cut -d/ -f 2)
-
-  # Check if any relevant smdebug files were modified.
-  if [ $root_folder = "smdebug" ] && [[ $framework_folder = "core" || $framework_folder = "profiler" || $framework_folder = "$framework" ]]; then
-    echo "true"
-#    return
-  fi
-
-  # Check if relevant files for running profiler integration tests were modified.
-  if [ $root_folder = "config" ] && [ $framework_folder = "profiler" ]; then
-    echo "true"
-#    return
-  fi
-
-done
-
-echo "false"
+CODEBUILD_GIT_BRANCH=$(git describe --contains --all HEAD);
 
 disable_integration_tests="true"
 if [ $disable_integration_tests = "true" ]

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -11,11 +11,7 @@ fi
 
 check_changed_files() {
   # Get the branch we're running integration tests on.
-  export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
-  if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-    CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)";
-    export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
-  fi
+  export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
 
   # If the branch is master, then just run integration tests.
   if [ $CODEBUILD_GIT_BRANCH = "master" ]; then
@@ -25,7 +21,7 @@ check_changed_files() {
 
   # Otherwise, check to see what files have changed in this branch. If files in smdebug/core or smdebug/profiler or
   # smdebug/$framework have been modified, run the integration tests. Otherwise, don't run the integration tests.
-  for file in $(git diff --name-only master $CODEBUILD_GIT_BRANCH 2>/dev/null)
+  for file in $(git diff --name-only master $CODEBUILD_GIT_BRANCH)
   do
     root_folder=$(echo $file | cut -d/ -f 1)
     framework_folder=$(echo $file | cut -d/ -f 2)

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -2,13 +2,7 @@
 
 # To manually disable profiler integration tests from running in the PR CI, set this environment variable to "true".
 # If you do this, remember to reset it back to "false" before merging the PR.
-echo "Start profiler integration tests script."
-
-echo "base ref" $CODEBUILD_WEBHOOK_HEAD_REF
-CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/}
-echo $CODEBUILD_GIT_BRANCH
-
-disable_integration_tests="true"
+disable_integration_tests="false"
 if [ $disable_integration_tests = "true" ]
 then
   echo "PROFILER INTEGRATION TESTS MANUALLY DISABLED!"
@@ -20,7 +14,7 @@ check_changed_files() {
   export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
   if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
     CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }' 2>/dev/null)";
-    export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
+    export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
   fi
 
   # If the branch is master, then just run integration tests.


### PR DESCRIPTION
### Description of changes:
Unrelated git errors spam the logs of the profiler integration test builds that are run as part of the PR CI. This change fixes that by using a CodeBuild env variable to determine the current branch instead of git commands..

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
