### PR TITLE
Fix: Incompatible Numpy Version on CI

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -44,8 +44,8 @@ phases:
       # We do not need to force install smdebug-rules. The container used for PR builds do not have smdebug rules binary.
       # Force installing rules binary attempts to re-install ipython-genutils which fails on PyTorch Ubuntu 16.04 containers.
       - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal
-      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --force-reinstall $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
-      - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
+      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --U $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
+      - cd $CODEBUILD_SRC_DIR  && pip install --U dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug
       - pip show smdebug_rules

--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -44,8 +44,8 @@ phases:
       # We do not need to force install smdebug-rules. The container used for PR builds do not have smdebug rules binary.
       # Force installing rules binary attempts to re-install ipython-genutils which fails on PyTorch Ubuntu 16.04 containers.
       - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal
-      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --U $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
-      - cd $CODEBUILD_SRC_DIR  && pip install --U dist/*.whl && cd ..
+      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install -U $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
+      - cd $CODEBUILD_SRC_DIR  && pip install -U dist/*.whl && cd ..
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug
       - pip show smdebug_rules

--- a/config/buildspec_xgboost_1_2_1.yml
+++ b/config/buildspec_xgboost_1_2_1.yml
@@ -1,0 +1,60 @@
+# Build Spec for AWS CodeBuild CI for XGBoost 1.2-1
+# CPU Container Used: 683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.2-1-cpu-py3
+# GPU Container Used: 683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.2-1
+
+# Note: The xgboost team maintains a single container for both CPU and GPU
+# There is no special image tag for GPU containers;
+
+version: 0.2
+
+env:
+  variables:
+    run_pytest_pytorch: "disable"
+    run_pytest_mxnet: "disable"
+    run_pytest_tensorflow: "disable"
+    run_pytest_tensorflow2: "disable"
+    run_pytest_profiler: "disable"
+    run_pytest_xgboost: "enable"
+    run_integration_pytest_pytorch: "disable"
+    run_integration_pytest_mxnet: "disable"
+    run_integration_pytest_tensorflow: "disable"
+    run_integration_pytest_tensorflow2: "disable"
+    run_integration_pytest_xgboost: "enable"
+    zero_code_change_test: "enable"
+    code_coverage_smdebug_rules: "true"
+
+phases:
+  install:
+    commands:
+        # The XGBoost container requires an update PUB_KEY to run the apt-get update
+        - if [ "$run_pytest_xgboost" = "enable" ]; then su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D; fi
+        -  . config/change_branch.sh #EXPORTS BRANCHES FOR OTHER REPOS AND CURRENT REPO.
+        - su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D && apt-get update
+        - apt-get install sudo -qq -o=Dpkg::Use-Pty=0 # silence output: https://askubuntu.com/a/668859/724247
+        - cd $CODEBUILD_SRC_DIR && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
+        - pip install --upgrade pip==19.3.1
+        - pip install -q pytest==6.1.2 pytest-cov==2.10.1 wheel==0.35.1 pyYaml==5.3.1 pytest-html==3.0.0 sagemaker==2.16.3 pre-commit==2.6.0
+        - pip install -q matplotlib==3.3.1 && pip3 install seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3
+        - pip uninstall -y boto3 && pip uninstall -y aiobotocore && pip uninstall -y botocore
+        - pip uninstall -y typing # see: https://t.corp.amazon.com/P43975146/overview
+
+  pre_build:
+    commands:
+      - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+      - cd $RULES_CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+
+  build:
+    commands:
+      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install --upgrade -U dist/*.whl && cd ..
+      - cd $CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal && pip install dist/*.whl && cd ..
+      - cd $RULES_CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && ./config/tests.sh  && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
+      - cd $CODEBUILD_SRC_DIR && chmod +x config/tests.sh && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && ./config/tests.sh  && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
+      - echo 'Connect to CodeCov'
+      - bash $CODEBUILD_SRC_DIR/config/codecov.sh
+
+  post_build:
+    commands:
+      - rm -rf $CODEBUILD_SRC_DIR/upload/$CURRENT_COMMIT_PATH
+      - rm -rf $RULES_CODEBUILD_SRC_DIR/upload/$CURRENT_COMMIT_PATH
+      - if [ "$CODEBUILD_BUILD_SUCCEEDING" -eq 0 ]; then echo "ERROR BUILD FAILED " && exit 1 ; fi
+      - if [ "$CODEBUILD_BUILD_SUCCEEDING" -eq 1 ]; then echo "INFO BUILD SUCCEEDED !!! " ; fi

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ FRAMEWORKS = ["tensorflow", "pytorch", "mxnet", "xgboost"]
 TESTS_PACKAGES = ["pytest", "torchvision", "pandas"]
 INSTALL_REQUIRES = [
     "protobuf>=3.6.0",
-    "numpy>1.16.0,<2.0.0",
+    "numpy>1.16.0,<1.19.0",
     "packaging",
     "boto3>=1.10.32",
     "pyinstrument>=3.1.3",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ FRAMEWORKS = ["tensorflow", "pytorch", "mxnet", "xgboost"]
 TESTS_PACKAGES = ["pytest", "torchvision", "pandas"]
 INSTALL_REQUIRES = [
     "protobuf>=3.6.0",
-    "numpy>1.16.0,<1.19.0",
+    "numpy>=1.16.0",
     "packaging",
     "boto3>=1.10.32",
     "pyinstrument>=3.1.3",


### PR DESCRIPTION
### Description of changes:
- Tensorflow 2.3.1 requires numpy versions to be in the range: `numpy>1.16.0,<1.19.0`
- The latest numpy version is at `1.20.0`
- Adding the changes of #432 to this same PR to unblock the xgboost CI.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
