### PR TITLE
Revert "Split inputs to save nested structures (#427)"

### DIFF
--- a/config/buildspec_tensorflow_2_3.yml
+++ b/config/buildspec_tensorflow_2_3.yml
@@ -49,6 +49,7 @@ phases:
       # Force installing rules binary attempts to re-install ipython-genutils which fails on PyTorch Ubuntu 16.04 containers.
       - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal
       - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
+      - pip install --force-reinstall numpy==1.18.5
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug
       - pip show smdebug_rules

--- a/config/buildspec_tensorflow_2_3.yml
+++ b/config/buildspec_tensorflow_2_3.yml
@@ -52,7 +52,6 @@ phases:
       - pip install --force-reinstall numpy==1.18.5
       - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
       - pip show smdebug
-      - pip show smdebug_rules
       - echo 'Uploading Coverage to CodeCov'
       - bash $CODEBUILD_SRC_DIR/config/codecov.sh
       - cd $RULES_CODEBUILD_SRC_DIR && chmod +x config/tests.sh && PYTHONPATH=. && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && ./config/tests.sh  && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..

--- a/smdebug/analysis/utils.py
+++ b/smdebug/analysis/utils.py
@@ -21,14 +21,6 @@ def no_refresh(trials):
         trial.dynamic_refresh = True
 
 
-def _tensor_name_sorter(t_name):
-    # sorts t_names based on their numerical suffix
-    # currently used to sort internally named input
-    # and output tensors
-    t_name = t_name.split("_")[-1]
-    return int(t_name)
-
-
 @contextmanager
 def refresh(trials):
     if isinstance(trials, list):

--- a/smdebug/core/tfevent/event_file_reader.py
+++ b/smdebug/core/tfevent/event_file_reader.py
@@ -34,7 +34,6 @@ def as_dtype(t):
         types_pb2.DT_HALF: np.float16,
         types_pb2.DT_FLOAT: np.float32,
         types_pb2.DT_DOUBLE: np.float64,
-        types_pb2.DT_INT8: np.uint8,
         types_pb2.DT_INT32: np.int32,
         types_pb2.DT_INT64: np.int64,
         types_pb2.DT_STRING: np.str,

--- a/smdebug/core/tfevent/util.py
+++ b/smdebug/core/tfevent/util.py
@@ -13,7 +13,7 @@ logger = get_logger()
 # hash value of ndarray.dtype is not the same as np.float class
 # so we need to convert the type classes below to np.dtype object
 _NP_DATATYPE_TO_PROTO_DATATYPE = {
-    np.dtype(np.float16): "DT_HALF",
+    np.dtype(np.float16): "DT_INT32",
     np.dtype(np.float32): "DT_FLOAT",
     np.dtype(np.float64): "DT_DOUBLE",
     np.dtype(np.int32): "DT_INT32",

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -538,34 +538,22 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                     g = g.values
                 self._save_tensor_to_file(export_name, g, collections_to_write)
 
-    def _save_model_inputs_and_outputs_helper(self, collection_key, tensors_to_save, prefix):
-        collections_to_write = (
-            {self.get_collection(collection_key)}
-            if self._is_collection_being_saved_for_step(collection_key)
-            else set()
-        )
-        if isinstance(tensors_to_save, (dict, list)):
-            tensors_to_save = nest.flatten(tensors_to_save)
-        else:
-            tensors_to_save = [tensors_to_save]
-        for idx, t_value in enumerate(tensors_to_save):
-            t_name = f"{prefix}_{idx}"
-            self._save_tensor_to_file(t_name, t_value, collections_to_write)
-
     def save_smdebug_logs(self, logs):
         if logs is None:
             return
 
         for key in logs:
+            tensors_to_save = []
+            collections_to_write = set()
             if SMDEBUG_PREFIX in key:
                 # Save Model Outputs
-                if key == ModelOutput.LABELS:
-                    self._save_model_inputs_and_outputs_helper(
-                        CollectionKeys.OUTPUTS, logs[key], prefix="labels"
-                    )
-                elif key == ModelOutput.PREDICTIONS:
-                    self._save_model_inputs_and_outputs_helper(
-                        CollectionKeys.OUTPUTS, logs[key], prefix="pred"
+                if key in ModelOutputs:
+                    export_name = get_model_output_export_name(key)
+                    tensors_to_save.append((export_name, logs[key]))
+                    collections_to_write = (
+                        {self.get_collection(CollectionKeys.OUTPUTS)}
+                        if self._is_collection_being_saved_for_step(CollectionKeys.OUTPUTS)
+                        else set()
                     )
                 # Save Gradients
                 elif key == SMDEBUG_GRADIENTS_KEY:
@@ -575,9 +563,19 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                     self._save_layer_values(logs[key])
                 # Save Model Inputs
                 elif key in ModelInputs:
-                    self._save_model_inputs_and_outputs_helper(
-                        CollectionKeys.INPUTS, logs[key], prefix="inputs"
+                    export_name = get_model_input_export_name()
+                    tensors_to_save.append((export_name, logs[key]))
+                    collections_to_write = (
+                        {self.get_collection(CollectionKeys.INPUTS)}
+                        if self._is_collection_being_saved_for_step(CollectionKeys.INPUTS)
+                        else set()
                     )
+                for t_name, t_value in tensors_to_save:
+                    if isinstance(t_value, dict):
+                        # flatten the inputs and labels
+                        # since we cannot convert dicts into numpy
+                        t_value = nest.flatten(t_value)
+                    self._save_tensor_to_file(t_name, t_value, collections_to_write)
 
     def _save_metrics(self, batch, logs, force_save=False):
         # if force_save is True, doesn't check whether collection needs to be saved for steps
@@ -949,34 +947,14 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                 layer_name = layer_name.name
             elif isinstance(layer_name, bytes):
                 layer_name = str(layer_name, "utf-8")
-            layer_input_tensor_name = get_export_name_for_keras(str(layer_name), "input")
             if len(layer_input) == 1:
                 # Layer Inputs are flattened and passed as a list into
                 # the next layer. Unpacking it speeds up the _make_numpy fn.
                 layer_input = layer_input[0]
-                self._save_tensor_to_file(
-                    f"{layer_input_tensor_name}_{0}", layer_input, collections_to_write
-                )
-            else:
-                for idx, layer_input_tensor in enumerate(layer_input):
-                    layer_input_tensor_name_with_idx = f"{layer_input_tensor_name}_{idx}"
-                    self._save_tensor_to_file(
-                        layer_input_tensor_name_with_idx, layer_input_tensor, collections_to_write
-                    )
+            layer_input_tensor_name = get_export_name_for_keras(str(layer_name), "input")
+            self._save_tensor_to_file(layer_input_tensor_name, layer_input, collections_to_write)
             layer_output_tensor_name = get_export_name_for_keras(str(layer_name), "output")
-            if isinstance(layer_output, list):
-                for idx, l_output in enumerate(layer_output):
-                    layer_output_tensor_name_with_idx = f"{layer_output_tensor_name}_{idx}"
-                    self._save_tensor_to_file(
-                        layer_output_tensor_name_with_idx, l_output, collections_to_write
-                    )
-            else:
-                # Saving layer output values as a list using the _make_numpy fn
-                # is slow. Saving them as tensors when they're not lists improved performance.
-                layer_output_tensor_name_with_idx = f"{layer_output_tensor_name}_{0}"
-                self._save_tensor_to_file(
-                    layer_output_tensor_name_with_idx, layer_output, collections_to_write
-                )
+            self._save_tensor_to_file(layer_output_tensor_name, layer_output, collections_to_write)
 
     def _write_optimizer_variables(self):
         optimizer_collections = self.collection_manager.get(CollectionKeys.OPTIMIZER_VARIABLES)

--- a/smdebug/trials/trial.py
+++ b/smdebug/trials/trial.py
@@ -5,9 +5,9 @@ from abc import ABC, abstractmethod
 from bisect import bisect_left
 
 # First Party
-from smdebug.analysis.utils import _tensor_name_sorter, refresh
+from smdebug.analysis.utils import refresh
 from smdebug.core.access_layer.utils import has_training_ended
-from smdebug.core.collection import Collection, CollectionKeys
+from smdebug.core.collection import Collection
 from smdebug.core.config_constants import (
     INCOMPLETE_STEP_WAIT_WINDOW_DEFAULT,
     INCOMPLETE_STEP_WAIT_WINDOW_KEY,
@@ -364,44 +364,7 @@ class Trial(ABC):
             rval.update(self._tensors_matching_regex(regex))
         return rval
 
-    def inputs(self, step, mode=ModeKeys.GLOBAL):
-        input_tensors_names = sorted(
-            self.tensor_names(
-                show_prefixed_tensors=True, step=step, mode=mode, collection=CollectionKeys.INPUTS
-            ),
-            key=_tensor_name_sorter,
-        )
-        input_tensors = [
-            self.tensor(tensor_name).value(step) for tensor_name in input_tensors_names
-        ]
-        return input_tensors
-
-    def _get_output_tensors_helper(self, step, mode, regex):
-        output_tensors_names = sorted(
-            self.tensor_names(show_prefixed_tensors=True, step=step, mode=mode, regex="labels_*"),
-            key=_tensor_name_sorter,
-        )
-        output_tensors = [
-            self.tensor(tensor_name).value(step) for tensor_name in output_tensors_names
-        ]
-        return output_tensors
-
-    def labels(self, step, mode=ModeKeys.GLOBAL):
-        return self._get_output_tensors_helper(step, mode, regex="labels_*")
-
-    def predictions(self, step, mode=ModeKeys.GLOBAL):
-        return self._get_output_tensors_helper(step, mode, regex="pred_*")
-
-    # * is used in python to force usage of named arguments
-    def tensor_names(
-        self,
-        show_prefixed_tensors=False,
-        *,
-        step=None,
-        mode=ModeKeys.GLOBAL,
-        regex=None,
-        collection=None,
-    ) -> list:
+    def tensor_names(self, *, step=None, mode=ModeKeys.GLOBAL, regex=None, collection=None) -> list:
         self.maybe_refresh()
         ts = set()
         if step is None and mode == ModeKeys.GLOBAL:

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -772,6 +772,7 @@ def test_keras_fit_pure_eager(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == (2 if is_tf_2_2() else 0)
 
 
+@pytest.mark.skip  # skip until aws tf update
 def test_model_inputs_and_outputs(out_dir, tf_eager_mode):
     # explicitly save INPUTS and OUTPUTS
     include_collections = [CollectionKeys.INPUTS, CollectionKeys.OUTPUTS]
@@ -788,11 +789,13 @@ def test_model_inputs_and_outputs(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.INPUTS)) == 1
 
+    for tname in trial.tensor_names(collection=CollectionKeys.OUTPUTS):
+        output = trial.tensor(tname)
+        assert tname in ["y", "y_pred"]
+        assert output.value(0) is not None
     # Check the shape of output tensors
-    assert trial.labels(step=0)[0].shape == (6000, 1)
-    assert trial.predictions(step=0)[0].shape == (6000, 1)
-    # Check the shape of input tensors
-    assert trial.inputs(step=0)[0].shape == (6000, 28, 28)
+    assert trial.tensor("y").value(0).shape[1] == 1  # label
+    assert trial.tensor("y_pred").value(0).shape[1] == 10  # Output probability for each class
 
 
 @pytest.mark.skip  # skip until aws tf update

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -82,6 +82,9 @@ def test_subclassed_model(out_dir):
     assert trial.tensor_names(collection=smd.CollectionKeys.LOSSES) == ["loss"]
     if is_tf_2_2():
         # Feature to save model inputs and outputs was first added for TF 2.2.0
-        assert trial.tensor_names(collection=smd.CollectionKeys.INPUTS) == ["inputs_0"]
-        assert trial.tensor_names(collection=smd.CollectionKeys.OUTPUTS) == ["labels_0", "pred_0"]
+        assert trial.tensor_names(collection=smd.CollectionKeys.INPUTS) == ["model_input"]
+        assert trial.tensor_names(collection=smd.CollectionKeys.OUTPUTS) == [
+            "labels",
+            "predictions",
+        ]
         assert len(trial.tensor_names(collection=smd.CollectionKeys.GRADIENTS)) == 6

--- a/tests/tensorflow2/test_support_dicts.py
+++ b/tests/tensorflow2/test_support_dicts.py
@@ -44,5 +44,5 @@ def test_support_dicts(out_dir):
     model.fit(inputs, labels, batch_size=16, epochs=10, callbacks=[smdebug_hook])
     model.save(out_dir, save_format="tf")
     trial = create_trial(out_dir)
-    assert trial.tensor_names(collection=CollectionKeys.INPUTS) == ["inputs_0"]
-    assert trial.tensor_names(collection=CollectionKeys.OUTPUTS) == ["labels_0", "pred_0"]
+    assert trial.tensor_names(collection=CollectionKeys.INPUTS) == ["model_input"]
+    assert trial.tensor_names(collection=CollectionKeys.OUTPUTS) == ["labels", "predictions"]

--- a/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
+++ b/tests/zero_code_change/test_tensorflow2_gradtape_integration.py
@@ -119,7 +119,7 @@ def helper_test_keras_v2_gradienttape(
                 # Inputs and Outputs are not saved with the default collection configurations.
                 assert len(trial.tensor_names(collection="inputs")) > 0
                 assert len(trial.tensor_names(collection="outputs")) > 0
-                assert trial.tensor_names(collection="outputs") == ["pred_0"]
+                assert trial.tensor_names(collection="outputs") == ["predictions"]
                 if "dense_layers" in json_file_contents:
                     # Only assert for test_keras_v2_multi_collections
                     # which defines this custom collection


### PR DESCRIPTION
Reverts awslabs/sagemaker-debugger#427

- This PR causes an error in `test_keras.py`
- Missed this due to CI issues which have since been resolved.