### PR TITLE
Pin Numpy Version For Vanilla Codebuild Container

### DIFF
--- a/config/buildspec_vanilla_framework_tests.yml
+++ b/config/buildspec_vanilla_framework_tests.yml
@@ -22,6 +22,7 @@ phases:
         - pip install --upgrade pip==20.3.3
         - pip install -q -U pytest pytest-cov wheel pyYaml pytest-html keras==2.3.1 mxnet torch xgboost pre-commit tensorflow_datasets==4.0.1 torchvision
         - cd $CODEBUILD_SRC_DIR && chmod +x config/install_smdebug.sh && chmod +x config/check_smdebug_install.sh && ./config/install_smdebug.sh;
+        - pip install --force-reinstall numpy==1.18.5
 
   build:
     commands:


### PR DESCRIPTION
### Description of changes:
- New numpy version breaks the TF tests. Pinning it to a compatible version

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
