### PR TITLE
Remove Pre-commit from xgboost buildspec

### DIFF
--- a/config/buildspec_xgboost_1_2_1.yml
+++ b/config/buildspec_xgboost_1_2_1.yml
@@ -41,8 +41,8 @@ phases:
 
   pre_build:
     commands:
-      - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
-      - cd $RULES_CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+      - cd $CODEBUILD_SRC_DIR
+      - cd $RULES_CODEBUILD_SRC_DIR
 
   build:
     commands:

--- a/config/buildspec_xgboost_1_2_1.yml
+++ b/config/buildspec_xgboost_1_2_1.yml
@@ -28,9 +28,10 @@ phases:
     commands:
         # The XGBoost container requires an update PUB_KEY to run the apt-get update
         - if [ "$run_pytest_xgboost" = "enable" ]; then su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D; fi
-        -  . config/change_branch.sh #EXPORTS BRANCHES FOR OTHER REPOS AND CURRENT REPO.
         - su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D && apt-get update
         - apt-get install sudo -qq -o=Dpkg::Use-Pty=0 # silence output: https://askubuntu.com/a/668859/724247
+        - pip install awscli
+        - . config/change_branch.sh #EXPORTS BRANCHES FOR OTHER REPOS AND CURRENT REPO.
         - cd $CODEBUILD_SRC_DIR && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
         - pip install -q pytest==6.1.2 pytest-cov==2.10.1 wheel==0.35.1 pyYaml==5.3.1 pytest-html==3.0.0 sagemaker==2.16.3 pre-commit==2.6.0

--- a/config/buildspec_xgboost_1_2_1.yml
+++ b/config/buildspec_xgboost_1_2_1.yml
@@ -30,7 +30,7 @@ phases:
         - if [ "$run_pytest_xgboost" = "enable" ]; then su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D; fi
         - su && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv 684BA42D && apt-get update
         - apt-get install sudo -qq -o=Dpkg::Use-Pty=0 # silence output: https://askubuntu.com/a/668859/724247
-        - pip install awscli
+        - pip install awscli==1.19.5
         - . config/change_branch.sh #EXPORTS BRANCHES FOR OTHER REPOS AND CURRENT REPO.
         - cd $CODEBUILD_SRC_DIR && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1


### PR DESCRIPTION
### Description of changes:
- codepipeline convert the source to a zip file and hence the source repository loses the `.git` meta 
- running git specific commands causes failures in the nightly

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
