### PR TITLE
SMDDP should use size() and rank() for TF jobs

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -30,7 +30,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==20.3.3
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3
+        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 

--- a/config/buildspec_tensorflow_2_3.yml
+++ b/config/buildspec_tensorflow_2_3.yml
@@ -35,7 +35,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3
+        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 
   pre_build:

--- a/config/buildspec_tensorflow_2_4.yml
+++ b/config/buildspec_tensorflow_2_4.yml
@@ -30,7 +30,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3
+        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 

--- a/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_3_1_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_3_1_integration_tests.yml
@@ -4,7 +4,7 @@ version: 0.2
 env:
   variables:
     use_current_branch: "true"
-    enable_smdataparallel_tests: "false"
+    enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "tensorflow"
 phases:

--- a/config/profiler/requirements.txt
+++ b/config/profiler/requirements.txt
@@ -10,3 +10,4 @@ pytest-cov==2.10.1
 flaky==3.7.0
 pytest-xdist==2.2.0
 pandas==1.1.5
+simplejson==3.17.2

--- a/config/profiler/requirements.txt
+++ b/config/profiler/requirements.txt
@@ -10,4 +10,3 @@ pytest-cov==2.10.1
 flaky==3.7.0
 pytest-xdist==2.2.0
 pandas==1.1.5
-simplejson==3.17.2


### PR DESCRIPTION
### Description of changes:
Fixing a bug introduced by #425 where `get_size()` and `get_rank()` were used for all jobs, when the correct API for TF jobs is actually is actually `size()` and `rank()`.

This bug was missed before because we do not have any tests that run TF SMDDP jobs.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
