### PR TITLE
[bugfix] Do not wrap models when the hook has a default_config

### DIFF
--- a/10272.json
+++ b/10272.json
@@ -1,0 +1,4 @@
+{"MetricName": "batch_TRAIN", "Value": 0.0, "Timestamp": 1614919309.1450195, "IterationNumber": 0}
+{"MetricName": "loss_TRAIN", "Value": 0.7228637933731079, "Timestamp": 1614919309.1460998, "IterationNumber": 0}
+{"MetricName": "batch_TRAIN", "Value": 0.0, "Timestamp": 1614919311.8004625, "IterationNumber": 9}
+{"MetricName": "loss_TRAIN", "Value": 0.6577014923095703, "Timestamp": 1614919311.8011003, "IterationNumber": 9}

--- a/10272.json
+++ b/10272.json
@@ -1,4 +1,0 @@
-{"MetricName": "batch_TRAIN", "Value": 0.0, "Timestamp": 1614919309.1450195, "IterationNumber": 0}
-{"MetricName": "loss_TRAIN", "Value": 0.7228637933731079, "Timestamp": 1614919309.1460998, "IterationNumber": 0}
-{"MetricName": "batch_TRAIN", "Value": 0.0, "Timestamp": 1614919311.8004625, "IterationNumber": 9}
-{"MetricName": "loss_TRAIN", "Value": 0.6577014923095703, "Timestamp": 1614919311.8011003, "IterationNumber": 9}

--- a/config/buildspec_tensorflow_2_3.yml
+++ b/config/buildspec_tensorflow_2_3.yml
@@ -35,7 +35,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2
+        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2 transformers==4.2.1
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 
   pre_build:

--- a/config/buildspec_tensorflow_2_4.yml
+++ b/config/buildspec_tensorflow_2_4.yml
@@ -30,7 +30,7 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2
+        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2 transformers==4.2.1
         - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -31,6 +31,7 @@ run_for_framework() {
       elif [ "$1" = "tensorflow2" ] ; then
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow2_gradtape_integration.py
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow2_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_tensorflow2_bert.py
       fi
 
     else

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -167,7 +167,6 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         # It attaches a hook to every layer of the model to capture
         # layer values
         self.model = model
-        self._wrap_model_with_input_output_saver()
         self.has_registered_model = True
 
     def _get_matching_collections(
@@ -725,8 +724,8 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
 
     def _prepare_collections_for_tf2(self):
         self._prepare_collections()
-        if self.has_default_hook_configuration():
-            self._unwrap_model_with_input_output_saver()
+        if self.has_default_hook_configuration() is False:
+            self._wrap_model_with_input_output_saver()
 
     def on_epoch_begin(self, batch, logs=None):
         pass
@@ -817,12 +816,6 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             saver = InputOutputSaver()
             layer.register_hook(saver)
             self.saved_layers[layer.name] = saver
-
-    def _unwrap_model_with_input_output_saver(self):
-        if self.has_registered_model is False:
-            return
-        for layer in self.model.layers:
-            layer.call = layer.old_call
 
     def _on_any_batch_begin(self, batch, mode, logs=None):
         self.start = time.time()

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -726,6 +726,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
     def _prepare_collections_for_tf2(self):
         self._prepare_collections()
         if self.has_default_hook_configuration():
+            # wrapping the model is only supported if the hook does not have the default hook configuration
             self._unwrap_model_with_input_output_saver()
 
     def on_epoch_begin(self, batch, logs=None):

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -819,7 +819,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             self.saved_layers[layer.name] = saver
 
     def _unwrap_model_with_input_output_saver(self):
-        if self.has_registered_model is True:
+        if self.has_registered_model is False:
             return
         for layer in self.model.layers:
             layer.call = layer.old_call

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -36,14 +36,11 @@ from .utils import (
     ModelInput,
     ModelInputs,
     ModelOutput,
-    ModelOutputs,
     TFDistributionStrategy,
     get_export_name_for_keras,
     get_keras_layer_inputs,
     get_keras_layer_outputs,
     get_keras_mode,
-    get_model_input_export_name,
-    get_model_output_export_name,
     is_keras_optimizer,
     is_profiler_supported_for_tf_version,
     is_tf_version_2_3_x,
@@ -726,6 +723,11 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             x.fetch_callbacks.pop(tf_obj)
         self._fetches_added.clear()
 
+    def _prepare_collections_for_tf2(self):
+        self._prepare_collections()
+        if self.has_default_hook_configuration():
+            self._unwrap_model_with_input_output_saver()
+
     def on_epoch_begin(self, batch, logs=None):
         pass
 
@@ -751,7 +753,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         if self.prepared_collections is False and is_tf_version_2_3_x():
             # Addresses ordering issues in TF 2.3.0
             # sets prepared_collections to True here
-            self._prepare_collections()
+            self._prepare_collections_for_tf2()
             self._increment_step()
             self.step_incremented_in_on_train_begin = True
 
@@ -816,6 +818,13 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             layer.register_hook(saver)
             self.saved_layers[layer.name] = saver
 
+    def _unwrap_model_with_input_output_saver(self):
+        if self.has_registered_model is False:
+            return
+        for layer in self.model.layers:
+            layer.call = layer.old_call
+        self.has_registered_model = False
+
     def _on_any_batch_begin(self, batch, mode, logs=None):
         self.start = time.time()
         if self._is_not_supported():
@@ -866,13 +875,12 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
 
         if self.prepared_collections is False:
             # sets prepared_collections to True here
-            self._prepare_collections()
+            self._prepare_collections_for_tf2()
 
         if self._prepared_tensors[mode] is False:
             if (is_tf_version_2x() and tf.executing_eagerly()) or self._validate_exec_function(
                 self._get_exec_function(mode)
             ):
-                self._wrap_model_with_input_output_saver()
                 self._prepare_layers(mode)
                 self._prepare_non_layer_tensors()
                 self._prepare_tensors_available_post_step()
@@ -1172,7 +1180,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                 )
                 self.collection_manager.get(CollectionKeys.LOSSES).include(".*loss.*")
                 self.collection_manager.get(CollectionKeys.GRADIENTS).include("^gradient")
-                self._prepare_collections()
+                self._prepare_collections_for_tf2()
                 self.prepared_collections = True
 
             self._increment_step()

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -98,7 +98,6 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         )  # stores tensors custom tensors saved by users every step
         self.saved_layers = dict()
         self.has_registered_model = False
-        self.has_wrapped_model = False
 
         # Profiling vars
         self.tf_profiler = None
@@ -809,7 +808,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         self._on_any_mode_begin(ModeKeys.PREDICT)
 
     def _wrap_model_with_input_output_saver(self):
-        if self.has_registered_model or self.has_wrapped_model:
+        if self.has_registered_model:
             return
         for layer in self.model.layers:
             layer._hooks = []
@@ -818,14 +817,12 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             saver = InputOutputSaver()
             layer.register_hook(saver)
             self.saved_layers[layer.name] = saver
-        self.has_wrapped_model = True
 
     def _unwrap_model_with_input_output_saver(self):
         if self.has_registered_model is True:
             return
         for layer in self.model.layers:
             layer.call = layer.old_call
-        self.has_wrapped_model = False
 
     def _on_any_batch_begin(self, batch, mode, logs=None):
         self.start = time.time()

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -167,6 +167,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         # It attaches a hook to every layer of the model to capture
         # layer values
         self.model = model
+        self._wrap_model_with_input_output_saver()
         self.has_registered_model = True
 
     def _get_matching_collections(
@@ -724,8 +725,8 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
 
     def _prepare_collections_for_tf2(self):
         self._prepare_collections()
-        if self.has_default_hook_configuration() is False:
-            self._wrap_model_with_input_output_saver()
+        if self.has_default_hook_configuration():
+            self._unwrap_model_with_input_output_saver()
 
     def on_epoch_begin(self, batch, logs=None):
         pass
@@ -816,6 +817,12 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             saver = InputOutputSaver()
             layer.register_hook(saver)
             self.saved_layers[layer.name] = saver
+
+    def _unwrap_model_with_input_output_saver(self):
+        if self.has_registered_model is False:
+            return
+        for layer in self.model.layers:
+            layer.call = layer.old_call
 
     def _on_any_batch_begin(self, batch, mode, logs=None):
         self.start = time.time()

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -361,6 +361,7 @@ class InputOutputSaver:
 
 def get_layer_call_fn(layer: tf.keras.layers.Layer) -> Callable[[tf.Tensor], tf.Tensor]:
     old_call_fn = layer.call
+    layer.old_call = old_call_fn
 
     def call(inputs, *args, **kwargs) -> tf.Tensor:
         layer_input = inputs

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -361,7 +361,6 @@ class InputOutputSaver:
 
 def get_layer_call_fn(layer: tf.keras.layers.Layer) -> Callable[[tf.Tensor], tf.Tensor]:
     old_call_fn = layer.call
-    layer.old_call = old_call_fn
 
     def call(inputs, *args, **kwargs) -> tf.Tensor:
         layer_input = inputs

--- a/tests/zero_code_change/test_tensorflow2_bert.py
+++ b/tests/zero_code_change/test_tensorflow2_bert.py
@@ -1,0 +1,49 @@
+# Third Party
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from tests.utils import SagemakerSimulator
+from transformers import (
+    BertTokenizer,
+    TFBertForSequenceClassification,
+    glue_convert_examples_to_features,
+)
+
+# First Party
+import smdebug.tensorflow as smd
+from smdebug.core.collection import CollectionKeys
+
+
+def test_bert_simple():
+    # Test bert with the default smdebug configuration
+    smd.del_hook()
+    with SagemakerSimulator(enable_tb=False) as sim:
+        epochs = 1
+        model = TFBertForSequenceClassification.from_pretrained("bert-base-uncased")
+        tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+        data = tfds.load("glue/mrpc")
+        train_dataset = glue_convert_examples_to_features(
+            data["train"], tokenizer, max_length=128, task="mrpc"
+        )
+        train_dataset = train_dataset.shuffle(100).batch(32).repeat(2)
+        optimizer = tf.keras.optimizers.Adam(learning_rate=3e-5)
+        loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+        model.compile(optimizer=optimizer, loss=loss)
+        model.fit(train_dataset, epochs=epochs, steps_per_epoch=115)
+
+    hook = smd.get_hook()
+    assert hook.has_default_hook_configuration()
+    hook.close()
+    # Check that hook created and tensors saved
+    trial = smd.create_trial(path=sim.out_dir)
+    assert len(trial.steps()) > 0, "Nothing saved at any step."
+    assert len(trial.tensor_names()) > 0, "Tensors were not saved."
+
+    # DEFAULT TENSORS SAVED
+    assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) > 0, "No Losses Saved"
+    assert len(trial.tensor_names(collection=CollectionKeys.METRICS)) > 0, "No Metrics Saved"
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 0
+    ), "Weights were not expected to be saved by default"
+    assert (
+        len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 0
+    ), "Biases were not expected to be saved by default"

--- a/tests/zero_code_change/test_tensorflow2_bert.py
+++ b/tests/zero_code_change/test_tensorflow2_bert.py
@@ -28,7 +28,7 @@ def test_bert_simple():
         optimizer = tf.keras.optimizers.Adam(learning_rate=3e-5)
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
         model.compile(optimizer=optimizer, loss=loss)
-        model.fit(train_dataset, epochs=epochs, steps_per_epoch=115)
+        model.fit(train_dataset, epochs=epochs, steps_per_epoch=10)
 
     hook = smd.get_hook()
     assert hook.has_default_hook_configuration()


### PR DESCRIPTION
### Description of changes:
- Models will not be wrapped with default_hook_config


#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
