### PR TITLE
Pre commit build

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -36,7 +36,7 @@ phases:
 
   pre_build:
     commands:
-      - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+      - cd $CODEBUILD_SRC_DIR
 
   build:
     commands:

--- a/config/buildspec_pre_commit.yml
+++ b/config/buildspec_pre_commit.yml
@@ -6,10 +6,8 @@ phases:
         - su && apt-get update
         - apt-get install sudo -qq -o=Dpkg::Use-Pty=0 # silence output: https://askubuntu.com/a/668859/724247
         - sudo apt-get update -qq -o=Dpkg::Use-Pty=0
-        - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
-        - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
+        - pip install -q pre-commit awscli
 
   pre_build:
     commands:

--- a/config/buildspec_pre_commit.yml
+++ b/config/buildspec_pre_commit.yml
@@ -1,25 +1,4 @@
-# Build Spec for AWS CodeBuild CI TF 2.4.x CPU and GPU Containers
-# Containers Used:
-    # Note: The public DLC is not yet available so this buildspec is currently consuming a custom built container
-
 version: 0.2
-env:
-  variables:
-    run_pytest_pytorch: "disable"
-    run_pytest_mxnet: "disable"
-    run_pytest_tensorflow: "disable"
-    run_pytest_tensorflow2: "enable"
-    run_pytest_xgboost: "disable"
-    run_pytest_profiler: "enable"
-    run_integration_pytest_pytorch: "disable"
-    run_integration_pytest_mxnet: "disable"
-    run_integration_pytest_tensorflow: "disable"
-    run_integration_pytest_tensorflow2: "enable"
-    run_integration_pytest_xgboost: "disable"
-    # below needs to be enabled
-    zero_code_change_test: "enable"
-    # set code coverage flag
-    code_coverage_smdebug: "true"
 phases:
   install:
     commands:

--- a/config/buildspec_pre_commit.yml
+++ b/config/buildspec_pre_commit.yml
@@ -36,22 +36,12 @@ phases:
 
   pre_build:
     commands:
-      - cd $CODEBUILD_SRC_DIR
+      - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+      - cd $RULES_CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
 
   build:
     commands:
-      - cd $CODEBUILD_SRC_DIR  && python setup.py bdist_wheel --universal
-      # We do not need to force install smdebug-rules. The container used for PR builds do not have smdebug rules binary.
-      # Force installing rules binary attempts to re-install ipython-genutils which fails on PyTorch Ubuntu 16.04 containers.
-      - cd $RULES_CODEBUILD_SRC_DIR && python setup.py bdist_wheel --universal
-      - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --force-reinstall $RULES_CODEBUILD_SRC_DIR/dist/*.whl; else pip install $RULES_CODEBUILD_SRC_DIR/dist/*.whl; fi
-      - cd $CODEBUILD_SRC_DIR  && pip install --force-reinstall dist/*.whl && cd ..
-      - cd $CODEBUILD_SRC_DIR  && chmod +x config/tests.sh && PYTHONPATH=. && ./config/tests.sh  && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
-      - pip show smdebug
-      - pip show smdebug_rules
-      - echo 'Uploading Coverage to CodeCov'
-      - bash $CODEBUILD_SRC_DIR/config/codecov.sh
-      - cd $RULES_CODEBUILD_SRC_DIR && chmod +x config/tests.sh && PYTHONPATH=. && mkdir -p upload/$CURRENT_COMMIT_PATH/wheels && ./config/tests.sh  && cp ./dist/*.whl upload/$CURRENT_COMMIT_PATH/wheels && cd ..
+      - echo "PRE COMMIT SUCCESSFUL"
 
   post_build:
     commands:

--- a/config/buildspec_pre_commit.yml
+++ b/config/buildspec_pre_commit.yml
@@ -35,7 +35,6 @@ phases:
   pre_build:
     commands:
       - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
-      - cd $RULES_CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
 
   build:
     commands:

--- a/config/buildspec_pre_commit.yml
+++ b/config/buildspec_pre_commit.yml
@@ -30,8 +30,6 @@ phases:
         - sudo apt-get install unzip -qq -o=Dpkg::Use-Pty=0
         - cd $CODEBUILD_SRC_DIR  && chmod +x config/protoc_downloader.sh && ./config/protoc_downloader.sh
         - pip install --upgrade pip==19.3.1
-        - pip install -q matplotlib==3.3.1 seaborn==0.10.1 nbconvert==5.6.1 papermill==2.1.2 jupyter==1.0.0 scipy==1.5.2 scikit-learn==0.23.2 bokeh==2.2.3 simplejson==3.17.2 transformers==4.2.1
-        - if [ "$run_pytest_xgboost" = "enable" ]; then pip install --upgrade pyYaml==5.1; else pip install -q pyYaml; fi
         - pip install -q pytest wheel pytest-html pre-commit awscli pytest-cov
 
   pre_build:

--- a/config/buildspec_tensorflow_2_3.yml
+++ b/config/buildspec_tensorflow_2_3.yml
@@ -40,7 +40,7 @@ phases:
 
   pre_build:
     commands:
-      - cd $CODEBUILD_SRC_DIR && pre-commit install && pre-commit run --all-files
+      - cd $CODEBUILD_SRC_DIR
 
   build:
     commands:


### PR DESCRIPTION
### Description of changes:

- The nightly and release pipelines use the `config/buildspec_zero_code_change.yml` file which does not run the pre-commit validation step.
- However all the new changes to buildspecs are done to framework specific buildpsecs.
- We want to discontinue the use of the buildspec_zero_code_change.yml file and simply use framework specific buildspecs across all pipelines.
- However, in the release and nightly pipeline, code is not cloned from github but instead passed as an codebuild artifact across codebuild jobs
- pre-commit can only be run on git repositories and hence, this PR aims to run a the pre-commit step in a separate codebuild job for only PRs and remove it from framework specific buildspecs



#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
