### PR TITLE
Adding support for pytorch 1.8

### DIFF
--- a/config/profiler/buildspec_profiler_sagemaker_pytorch_1_8_0_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_pytorch_1_8_0_integration_tests.yml
@@ -1,0 +1,13 @@
+# Build Spec for AWS CodeBuild CI
+
+version: 0.2
+env:
+  variables:
+    use_current_branch: "true"
+    enable_smdataparallel_tests: "false"
+    force_run_tests: "false"
+    framework: "pytorch"
+phases:
+  build:
+    commands:
+      - chmod +x config/profiler/run_profiler_integration_tests.sh && ./config/profiler/run_profiler_integration_tests.sh

--- a/smdebug/pytorch/utils.py
+++ b/smdebug/pytorch/utils.py
@@ -1,4 +1,7 @@
 # Third Party
+# Standard Library
+from functools import lru_cache
+
 import numpy as np
 import torch
 from packaging import version
@@ -40,6 +43,7 @@ def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
     raise RuntimeError("Invalid reduction_name {0}".format(reduction_name))
 
 
+@lru_cache(maxsize=1)
 def is_pt_1_5():
     """
     Determine whether the version of torch is 1.5.x
@@ -48,6 +52,7 @@ def is_pt_1_5():
     return version.parse("1.5.0") <= PT_VERSION < version.parse("1.6.0")
 
 
+@lru_cache(maxsize=1)
 def is_pt_1_6():
     """
     Determine whether the version of torch is 1.6.x
@@ -56,9 +61,19 @@ def is_pt_1_6():
     return version.parse("1.6.0") <= PT_VERSION < version.parse("1.7.0")
 
 
+@lru_cache(maxsize=1)
 def is_pt_1_7():
     """
     Determine whether the version of torch is 1.7.x
     :return: bool
     """
     return version.parse("1.7.0") <= PT_VERSION < version.parse("1.8.0")
+
+
+@lru_cache(maxsize=1)
+def is_pt_1_8():
+    """
+    Determine whether the version of torch is 1.8.x
+    :return: bool
+    """
+    return version.parse("1.8.0") <= PT_VERSION < version.parse("1.9.0")


### PR DESCRIPTION
### Description of changes:
The PR contains code change to support the PT 1.8

The change is mainly due to the fact the PT1.8 has changed the signatures of private methods in torch autograd profiler.

There is no other functionality changes.

Testing:
The integration tests suite is currently running against this code change with DLC that contained the updated torch 1.8 binary wheel.
Here is the link: https://tiny.amazon.com/td0yc4z8/IsenLink

Ran the unit tests in the DLC container with PT1.8. The unit tests include eagleeye zero code change tests too

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
