### PR TITLE
Autoconfigure Losses Collection For  Xgboost

### DIFF
--- a/smdebug/xgboost/collection.py
+++ b/smdebug/xgboost/collection.py
@@ -14,7 +14,8 @@ class CollectionManager(BaseCollectionManager):
             self.create_collection(c)
         self.get(CollectionKeys.HYPERPARAMETERS).include("^hyperparameters/.*$")
         self.get(CollectionKeys.METRICS).include("^[a-zA-z]+-[a-zA-z0-9]+$")
-        self.get(CollectionKeys.LOSSES).include("^[a-zA-z]+-[a-zA-z0-9]+$")
+        # we exclude map and auc since they're not loss metrics
+        self.get(CollectionKeys.LOSSES).include("^[a-zA-z]+-.+(?<!(auc|map))$")
         self.get(CollectionKeys.PREDICTIONS).include("^predictions$")
         self.get(CollectionKeys.LABELS).include("^labels$")
         self.get(CollectionKeys.FEATURE_IMPORTANCE).include("^feature_importance/.*")

--- a/smdebug/xgboost/collection.py
+++ b/smdebug/xgboost/collection.py
@@ -14,6 +14,7 @@ class CollectionManager(BaseCollectionManager):
             self.create_collection(c)
         self.get(CollectionKeys.HYPERPARAMETERS).include("^hyperparameters/.*$")
         self.get(CollectionKeys.METRICS).include("^[a-zA-z]+-[a-zA-z0-9]+$")
+        self.get(CollectionKeys.LOSSES).include("^[a-zA-z]+-[a-zA-z0-9]+$")
         self.get(CollectionKeys.PREDICTIONS).include("^predictions$")
         self.get(CollectionKeys.LABELS).include("^labels$")
         self.get(CollectionKeys.FEATURE_IMPORTANCE).include("^feature_importance/.*")

--- a/smdebug/xgboost/constants.py
+++ b/smdebug/xgboost/constants.py
@@ -1,0 +1,1 @@
+INCREASING_METRICS_REGEX = "^[a-zA-z]+-(auc|map)$"

--- a/smdebug/xgboost/utils.py
+++ b/smdebug/xgboost/utils.py
@@ -6,6 +6,7 @@ import csv
 import logging
 import os
 import re
+from typing import List, Tuple
 
 # Third Party
 import numpy as np
@@ -126,6 +127,13 @@ def _get_num_valid_libsvm_features(libsvm_line):
         return num_sparse_features
     else:
         return 0
+
+
+def _filter_increasing_metric_names(metrics: List[Tuple]):
+    # auc and map are metrics that increase in value
+    # and should not be classified as losses
+    p = re.compile("^[a-zA-z]+-(auc|map)$")
+    return [metric_name for metric_name, metric_value in metrics if p.match(metric_name)]
 
 
 def _is_valid_libsvm_label(libsvm_label):

--- a/smdebug/xgboost/utils.py
+++ b/smdebug/xgboost/utils.py
@@ -6,7 +6,6 @@ import csv
 import logging
 import os
 import re
-from typing import List, Tuple
 
 # Third Party
 import numpy as np
@@ -127,13 +126,6 @@ def _get_num_valid_libsvm_features(libsvm_line):
         return num_sparse_features
     else:
         return 0
-
-
-def _filter_increasing_metric_names(metrics: List[Tuple]):
-    # auc and map are metrics that increase in value
-    # and should not be classified as losses
-    p = re.compile("^[a-zA-z]+-(auc|map)$")
-    return [metric_name for metric_name, metric_value in metrics if p.match(metric_name)]
 
 
 def _is_valid_libsvm_label(libsvm_label):

--- a/tests/xgboost/json_config.py
+++ b/tests/xgboost/json_config.py
@@ -49,3 +49,15 @@ def get_json_config_full(local_path):
         ],
     }
     return json.dumps(json_config)
+
+
+def get_json_config_full(local_path):
+    json_config = {
+        "S3Path": "s3://kjndjknd_bucket/prefix",
+        "LocalPath": local_path,
+        "HookParameters": {"save_all": False},
+        "CollectionConfigurations": [
+            {"CollectionName": "losses", "CollectionParameters": {"save_interval": 1}}
+        ],
+    }
+    return json.dumps(json_config)

--- a/tests/xgboost/json_config.py
+++ b/tests/xgboost/json_config.py
@@ -51,7 +51,7 @@ def get_json_config_full(local_path):
     return json.dumps(json_config)
 
 
-def get_json_config_full(local_path):
+def get_json_config_for_losses(local_path):
     json_config = {
         "S3Path": "s3://kjndjknd_bucket/prefix",
         "LocalPath": local_path,

--- a/tests/xgboost/run_xgboost_model.py
+++ b/tests/xgboost/run_xgboost_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import xgboost
 
 
-def run_xgboost_model(hook, num_round=10, seed=42):
+def run_xgboost_model(hook, num_round=10, seed=42, params=None):
 
     np.random.seed(seed)
 
@@ -15,7 +15,7 @@ def run_xgboost_model(hook, num_round=10, seed=42):
     test_label = np.random.randint(2, size=5)
     dtest = xgboost.DMatrix(test_data, label=test_label)
 
-    params = {}
+    params = params if params else {}
 
     xgboost.train(
         params,


### PR DESCRIPTION
### Description of changes:
- All the deep learning frameworks (mxnet, tensorflow, pytorch) have a collection called "losses", which saves loss tensors.
- xgboost calls the same tensor "metrics" and the collection "losses" has no meaning.
- The LossNotDecreasing Rule is a builtin rule, that by default attempts to save the "losses" collection.
- This leads to the error `InvalidCollection` being raised, which is meant to warn users about incorrect collection configurations, especially when they create custom collections.
- However, since the LossNotDecreasing Rule is 1P rule and must not exhibit this behavior.
- With this PR, I simply add the Losses collection with the same regex as Metrics so that unsuspecting customers do not run into issues with the 1P rule and the LossNotDecreasing Rule will work as expected.
- Documentation of the use of the LossNotDecreasing rule for xgboost overrides losses with metrics; see [link](https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-debugger/xgboost_builtin_rules/xgboost-regression-debugger-rules.ipynb), however it is not made explicit and I believe that users should not have to configure one particular builtin rule for a certain framework
- **Note:** This change only comes into effect if the user configures a losses collection without a regex or use the LossNotDecreasing 1P Rule

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
