### PR TITLE
[bugfix] wrap read metadata.json in a try except block

### DIFF
--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -83,7 +83,11 @@ class StateStore:
         """
         if os.path.exists(self._states_file):
             with open(self._states_file) as json_data:
-                parameters = json.load(json_data)
+                try:
+                    parameters = json.load(json_data)
+                except json.decoder.JSONDecodeError:
+                    logger.warning(f"{self._states_file} was empty")
+                    return
             for param in parameters:
                 ts_state = dict()
                 ts_state[TRAINING_RUN] = param[TRAINING_RUN]


### PR DESCRIPTION
### Description of changes:
- if the `metadata.json` file is empty there is potential that the hook will crash.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
