### PR TITLE
[Do-Not-Merge] Ignore sagemaker-uploading

### DIFF
--- a/smdebug/_version.py
+++ b/smdebug/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.8check_fix"
+__version__ = "1.0.8b"

--- a/smdebug/_version.py
+++ b/smdebug/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.8"
+__version__ = "1.0.8check_fix"

--- a/smdebug/core/state_store.py
+++ b/smdebug/core/state_store.py
@@ -33,6 +33,7 @@ class StateStore:
                     file != METADATA_FILENAME
                     and file != METADATA_FILENAME_S3_UPLOADED
                     and "sagemaker-uploaded" not in file
+                    and "sagemaker-uploading" not in file
                 ):
                     checkpoint_files.append(os.path.join(child, file))
         return sorted(checkpoint_files)


### PR DESCRIPTION
### Description of changes:
- We should ignore special status files that can be added by Sagemaker before determining if we should update the checkpointing directory.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
