### PR TITLE
[DO Not Merge] Avoid using 'default' keyword while invoking 'get' method

### DIFF
--- a/smdebug/core/logger.py
+++ b/smdebug/core/logger.py
@@ -37,7 +37,7 @@ class DuplicateLogFilter:
 
 def _get_log_level():
     default = "info"
-    log_level = os.environ.get("SMDEBUG_LOG_LEVEL", default=default)
+    log_level = os.environ.get("SMDEBUG_LOG_LEVEL", default)
     log_level = log_level.lower()
     allowed_levels = ["info", "debug", "warning", "error", "critical", "off"]
     if log_level not in allowed_levels:
@@ -64,7 +64,7 @@ def get_logger(name="smdebug"):
     global _logger_initialized
     if not _logger_initialized:
         worker_pid = f"{socket.gethostname()}:{os.getpid()}"
-        log_context = os.environ.get("SMDEBUG_LOG_CONTEXT", default=worker_pid)
+        log_context = os.environ.get("SMDEBUG_LOG_CONTEXT", worker_pid)
         level = _get_log_level()
         logger = logging.getLogger(name)
 
@@ -79,7 +79,7 @@ def get_logger(name="smdebug"):
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setFormatter(log_formatter)
 
-        if os.environ.get("SMDEBUG_LOG_ALL_TO_STDOUT", default="TRUE").lower() == "false":
+        if os.environ.get("SMDEBUG_LOG_ALL_TO_STDOUT", "TRUE").lower() == "false":
             stderr_handler = logging.StreamHandler(sys.stderr)
             min_level = logging.DEBUG
             # lets through all levels less than ERROR
@@ -96,7 +96,7 @@ def get_logger(name="smdebug"):
         # SMDEBUG_LOG_PATH is the full path to log file
         # by default, log is only written to stdout&stderr
         # if this is set, it is written to file
-        path = os.environ.get("SMDEBUG_LOG_PATH", default=None)
+        path = os.environ.get("SMDEBUG_LOG_PATH", None)
         if path is not None:
             fh = logging.FileHandler(path)
             fh.setFormatter(log_formatter)


### PR DESCRIPTION
### Description of changes:
As mentioned in the issue #418 customers may see the error because of having 'default' keyword in the 'get()' call.

This change avoid using this keyword argument in 'get()' call to avoid potential issues.

As mentioned in the issue, the tokenizer in transformers package is modifying the data type of os.environ from os.Environ to 'dict'.  The change in this PR is for protecting smdebug from such changes while keeping the behavior same.  

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
