### PR TITLE
Don't run distributed training profiler integration tests in PR CI

### DIFF
--- a/config/profiler/buildspec_profiler_sagemaker_pytorch_1_5_0_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_pytorch_1_5_0_integration_tests.yml
@@ -7,6 +7,7 @@ env:
     enable_smdataparallel_tests: "false"
     force_run_tests: "false"
     framework: "pytorch"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_pytorch_1_6_0_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_pytorch_1_6_0_integration_tests.yml
@@ -7,6 +7,7 @@ env:
     enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "pytorch"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_pytorch_1_7_0_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_pytorch_1_7_0_integration_tests.yml
@@ -4,9 +4,10 @@ version: 0.2
 env:
   variables:
     use_current_branch: "true"
-    enable_smdataparallel_tests: "false"
+    enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "pytorch"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_pytorch_1_8_0_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_pytorch_1_8_0_integration_tests.yml
@@ -4,9 +4,10 @@ version: 0.2
 env:
   variables:
     use_current_branch: "true"
-    enable_smdataparallel_tests: "false"
+    enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "pytorch"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_2_1_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_2_1_integration_tests.yml
@@ -7,6 +7,7 @@ env:
     enable_smdataparallel_tests: "false"
     force_run_tests: "false"
     framework: "tensorflow"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_3_1_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_3_1_integration_tests.yml
@@ -7,6 +7,7 @@ env:
     enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "tensorflow"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_4_1_integration_tests.yml
+++ b/config/profiler/buildspec_profiler_sagemaker_tensorflow_2_4_1_integration_tests.yml
@@ -7,6 +7,7 @@ env:
     enable_smdataparallel_tests: "true"
     force_run_tests: "false"
     framework: "tensorflow"
+    build_type: "pr"  # must be one of pr, nightly or release
 phases:
   build:
     commands:

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -14,7 +14,7 @@ check_changed_files() {
   export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
 
   # If the branch is master, then just run integration tests.
-  if [ $CODEBUILD_GIT_BRANCH = "" ]; then
+  if [[ $CODEBUILD_GIT_BRANCH = "" ]]; then
     echo "true"
     return
   fi

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -14,7 +14,7 @@ check_changed_files() {
   export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
 
   # If the branch is master, then just run integration tests.
-  if [ $CODEBUILD_GIT_BRANCH = "master" ]; then
+  if [ $CODEBUILD_GIT_BRANCH = "" ]; then
     echo "true"
     return
   fi

--- a/config/profiler/run_profiler_integration_tests.sh
+++ b/config/profiler/run_profiler_integration_tests.sh
@@ -13,7 +13,7 @@ check_changed_files() {
   # Get the branch we're running integration tests on.
   export CODEBUILD_GIT_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/};
 
-  # If the branch is master, then just run integration tests.
+  # If the branch is an empty string, that means the current branch is master and the integration tests will be run.
   if [[ $CODEBUILD_GIT_BRANCH = "" ]]; then
     echo "true"
     return


### PR DESCRIPTION
### Description of changes:
Followup to https://tiny.amazon.com/tdigde5x/IsenLink to update the profiler integration test buildspecs to have a new parameter `build_type`. For the PR CI, the default build type is left as `pr`. For the nightly and release pipeline, this environment variable is overridden with `nightly` and `release` respectively. You can verify the changes by looking at the builds for the TF and PT profiler integration tests and seeing that the distributed training tests are skipped in the PR CI.

Also updated the PT 1.7 and PT 1.8 profiler integration tests to enable the SMDDP profiler integration test for these builds.

Also fixed a bug in the profiler integration test script so that profiler integration tests are run by default if the source smdebug branch is master.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
