### PR TITLE
Skip BFloat Datatype In Testing

### DIFF
--- a/tests/tensorflow2/test_tensorflow2_datatypes.py
+++ b/tests/tensorflow2/test_tensorflow2_datatypes.py
@@ -2,14 +2,15 @@
 import numpy as np
 import pytest
 from tensorflow.python.framework.dtypes import _NP_TO_TF
-from tests.tensorflow2.utils import is_tf_2_2
+from tests.tensorflow2.utils import is_tf_2_2, is_tf_version_greater_than_2_5_x
 
 # First Party
 from smdebug.core.tfevent.util import _get_proto_dtype
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False, reason="Brain Float Is Unavailable in lower versions of TF"
+    is_tf_2_2() is False or is_tf_version_greater_than_2_5_x() is True,
+    reason="Brain Float Is Unavailable in these versions of TF",
 )
 def test_tensorflow2_datatypes():
     # _NP_TO_TF contains all the mappings

--- a/tests/tensorflow2/test_tensorflow2_datatypes.py
+++ b/tests/tensorflow2/test_tensorflow2_datatypes.py
@@ -31,5 +31,6 @@ def test_tensorflow2_datatypes():
         except Exception:
             if _NP_TO_TF[_type] != tf.bfloat16:
                 # bfloat16 is only supported on TPUs.
+                # TPUs are not available outside of Google Cloud.
                 assert False, f"{_type} not supported"
     assert True

--- a/tests/tensorflow2/test_tensorflow2_datatypes.py
+++ b/tests/tensorflow2/test_tensorflow2_datatypes.py
@@ -1,16 +1,16 @@
 # Third Party
 import numpy as np
 import pytest
+import tensorflow as tf
 from tensorflow.python.framework.dtypes import _NP_TO_TF
-from tests.tensorflow2.utils import is_tf_2_2, is_tf_version_greater_than_2_5_x
+from tests.tensorflow2.utils import is_tf_2_2
 
 # First Party
 from smdebug.core.tfevent.util import _get_proto_dtype
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False or is_tf_version_greater_than_2_5_x() is True,
-    reason="Brain Float Is Unavailable in these versions of TF",
+    is_tf_2_2() is False, reason="Brain Float Is Unavailable in these versions of TF"
 )
 def test_tensorflow2_datatypes():
     # _NP_TO_TF contains all the mappings
@@ -29,5 +29,7 @@ def test_tensorflow2_datatypes():
         try:
             _get_proto_dtype(np.dtype(_type))
         except Exception:
-            assert False, f"{_type} not supported"
+            if _NP_TO_TF[_type] != tf.bfloat16:
+                # bfloat16 is only supported on TPUs.
+                assert False, f"{_type} not supported"
     assert True

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -28,3 +28,7 @@ def is_tf_2_3():
 
 def is_tf_version_greater_than_2_4_x():
     return version.parse("2.4.0") <= TF_VERSION
+
+
+def is_tf_version_greater_than_2_5_x():
+    return version.parse("2.5.0") <= TF_VERSION

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -28,7 +28,3 @@ def is_tf_2_3():
 
 def is_tf_version_greater_than_2_4_x():
     return version.parse("2.4.0") <= TF_VERSION
-
-
-def is_tf_version_greater_than_2_5_x():
-    return version.parse("2.5.0") <= TF_VERSION


### PR DESCRIPTION
### Description of changes:
- BFloat is datatype that targets Tensorflow execution on TPUs
- Skipping the the check for the bfloat datatype since it is out of the scope of debugger testing

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
