### PR TITLE
Fix test for TF 2.3

### DIFF
--- a/tests/tensorflow2/test_should_save_tensor.py
+++ b/tests/tensorflow2/test_should_save_tensor.py
@@ -7,6 +7,7 @@ from smdebug.core.collection import CollectionKeys
 from smdebug.core.modes import ModeKeys
 from smdebug.tensorflow import SaveConfig
 from smdebug.tensorflow.constants import TF_DEFAULT_SAVED_COLLECTIONS
+from smdebug.tensorflow.utils import is_tf_version_2_3_x
 
 model = tf.keras.models.Sequential(
     [
@@ -30,7 +31,11 @@ def helper_create_hook(out_dir, collections, include_regex=None):
     hook.register_model(model)
     hook.set_mode(ModeKeys.TRAIN)
     hook._prepare_collections()
-    hook._increment_step()
+
+    # _increment_step will already be called in hook.on_train_begin for TF 2.3, don't call it again.
+    if not is_tf_version_2_3_x():
+        hook._increment_step()
+
     hook.on_train_begin()
     return hook
 

--- a/tests/tensorflow2/test_should_save_tensor.py
+++ b/tests/tensorflow2/test_should_save_tensor.py
@@ -7,7 +7,6 @@ from smdebug.core.collection import CollectionKeys
 from smdebug.core.modes import ModeKeys
 from smdebug.tensorflow import SaveConfig
 from smdebug.tensorflow.constants import TF_DEFAULT_SAVED_COLLECTIONS
-from smdebug.tensorflow.utils import is_tf_version_2_3_x
 
 model = tf.keras.models.Sequential(
     [
@@ -30,12 +29,8 @@ def helper_create_hook(out_dir, collections, include_regex=None):
 
     hook.register_model(model)
     hook.set_mode(ModeKeys.TRAIN)
-    hook._prepare_collections()
-
-    # _increment_step will already be called in hook.on_train_begin for TF 2.3, don't call it again.
-    if not is_tf_version_2_3_x():
-        hook._increment_step()
-
+    hook._prepare_collections_for_tf2()
+    hook._increment_step()
     hook.on_train_begin()
     return hook
 


### PR DESCRIPTION
### Description of changes:
#483 introduced [this change](https://github.com/awslabs/sagemaker-debugger/pull/483/files#diff-4735c4bf5e5c95768955acc43056504b184783eb3a057db7734a1d93d4ddba0aR764) which changed the behavior of the KerasHook's `_on_any_mode_begin` function. If `_prepare_collections_for_tf2` wasn't already called for TF 2.3 (instead of `_prepare_collections`), then that block of code is executed and the step is incremented.

However, this exposed a bug in the `tests/tensorflow2/test_save_tensor.py::test_should_save_tensor_with_tf_collection` test. The collections should for the test should be prepared with `_prepare_collections_for_tf2`, not `_prepare_collections`. This way, the block of code linked above is not executed for the test.

This issue wasn't seen before because the bug only appears for TF 2.3, and the CI/nightly pipeline run tests for TF 2.4.

Tested this change by creating a dummy build that runs the smdebug tests for TF 2.3 (so that the existing builds aren't modified). Passing build: https://tiny.amazon.com/11irx3fwg/IsenLink

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
