### PR TITLE
Add safety checks for TF2 error handling for GradientTape

### DIFF
--- a/smdebug/core/error_handling_agent.py
+++ b/smdebug/core/error_handling_agent.py
@@ -49,7 +49,7 @@ class ErrorHandlingAgent(object):
             """
             self.hook = hook
 
-        def catch_smdebug_errors(self, default_return_val=None, return_type=None):
+        def catch_smdebug_errors(self, default_return_val=None):
             """
             This function is designed to be wrapped around all smdebug functions that are called externally, so that any
             errors arising from the wrapped functions or the resulting smdebug or third party functions called are

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -1181,8 +1181,15 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         increment step.
         """
 
+        def default_callback(*args, **kwargs):
+            """
+            Only call the original push tape if it isn't already recording.
+            """
+            if not self.tape._recording:
+                return function(*args, **kwargs)
+
         @functools.wraps(function)
-        @error_handling_agent.catch_smdebug_errors(default_return_val=function)
+        @error_handling_agent.catch_smdebug_errors(default_return_val=default_callback)
         def run(*args, **kwargs):
             function(*args, **kwargs)
             if self._is_not_supported():
@@ -1290,8 +1297,15 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
         Using this to export collections
         """
 
+        def default_callback(*args, **kwargs):
+            """
+            Only call the original pop tape if it is already recording.
+            """
+            if self.tape._recording:
+                return function(*args, **kwargs)
+
         @functools.wraps(function)
-        @error_handling_agent.catch_smdebug_errors(default_return_val=function)
+        @error_handling_agent.catch_smdebug_errors(default_return_val=default_callback)
         def run(*args, **kwargs):
             function(*args, **kwargs)
             if self._is_not_supported():


### PR DESCRIPTION
### Description of changes:
Adding safety checks to the TF2 error handling for GradientTape:
- If smdebug is disabled and `push_tape` is called, only call the original `push_tape` function if the tape isn't already recording.
- If smdebug is disabled and `pop_tape` is called, only call the original `pop_tape` function if the tape is already recording.

These changes serve as stronger verification to ensure that the error handling agent does not throw an error while calling original tape functions when smdebug is disabled.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
