### PR TITLE
Add error handling for MXNet

### DIFF
--- a/config/tests.sh
+++ b/config/tests.sh
@@ -17,12 +17,12 @@ check_logs() {
 run_for_framework() {
     if [ "$zero_code_change_test" = "enable" ] ; then
       # ignoring some test becuase they require multiple frmaeworks to be installed, these tests need to be broken down
-#      python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
+      python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
       if [ "$1" = "mxnet" ] ; then
-#        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_error_handling_agent.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
         # we run test/rules once, mxnet build has configured permission for sns to run this test
-#        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/rules
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/rules
       elif [ "$1" = "pytorch" ] ; then
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_error_handling_agent.py
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_integration.py
@@ -63,9 +63,9 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-#python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
-#run_for_framework core
+run_for_framework core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -20,6 +20,7 @@ run_for_framework() {
       python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
       if [ "$1" = "mxnet" ] ; then
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
+        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_error_handling_agent.py
         # we run test/rules once, mxnet build has configured permission for sns to run this test
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/rules
       elif [ "$1" = "pytorch" ] ; then

--- a/config/tests.sh
+++ b/config/tests.sh
@@ -17,12 +17,12 @@ check_logs() {
 run_for_framework() {
     if [ "$zero_code_change_test" = "enable" ] ; then
       # ignoring some test becuase they require multiple frmaeworks to be installed, these tests need to be broken down
-      python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
+#      python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  --durations=50 --html=$REPORT_DIR/report_$1.html -v -s --self-contained-html --ignore=tests/core/test_paths.py --ignore=tests/core/test_index_utils.py --ignore=tests/core/test_collections.py tests/$1
       if [ "$1" = "mxnet" ] ; then
-        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
+#        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_gluon_integration.py
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_mxnet_error_handling_agent.py
         # we run test/rules once, mxnet build has configured permission for sns to run this test
-        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/rules
+#        python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/rules
       elif [ "$1" = "pytorch" ] ; then
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_error_handling_agent.py
         python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append}  tests/zero_code_change/test_pytorch_integration.py
@@ -63,9 +63,9 @@ export SMDEBUG_LOG_LEVEL=info
 
 export OUT_DIR=upload/$CURRENT_COMMIT_PATH
 export REPORT_DIR=$OUT_DIR/pytest_reports
-python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
+#python -m pytest ${code_coverage_smdebug:+--cov=./ --cov-append} -v -W=ignore --durations=50 --html=$REPORT_DIR/report_analysis.html --self-contained-html tests/analysis
 
-run_for_framework core
+#run_for_framework core
 
 if [ "$run_pytest_xgboost" = "enable" ] ; then
     run_for_framework xgboost

--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -6,6 +6,7 @@ from mxnet.ndarray import NDArray
 from smdebug.core.collection import DEFAULT_MXNET_COLLECTIONS, CollectionKeys
 from smdebug.core.hook import CallbackHook
 from smdebug.core.json_config import DEFAULT_WORKER_NAME
+from smdebug.core.utils import error_handling_agent
 from smdebug.mxnet.collection import CollectionManager
 from smdebug.mxnet.graph import _net2pb
 from smdebug.mxnet.singleton_utils import set_hook
@@ -126,6 +127,7 @@ class Hook(CallbackHook):
         return DEFAULT_MXNET_COLLECTIONS
 
     # This hook is invoked by trainer prior to running the forward pass.
+    @error_handling_agent.catch_smdebug_errors()
     def forward_pre_hook(self, block, inputs):
         if self.writer is not None:
             # Write the params and gradients of the
@@ -158,6 +160,7 @@ class Hook(CallbackHook):
         self._save_custom_tensors_post_step()
 
     # This hook is invoked by trainer after running the forward pass.
+    @error_handling_agent.catch_smdebug_errors()
     def forward_hook(self, block, inputs, outputs):
         if not self._get_collections_to_save_for_step():
             return
@@ -213,6 +216,7 @@ class Hook(CallbackHook):
         # for compatibility with ZCC patches which call this
         self.register_block(block)
 
+    @error_handling_agent.catch_smdebug_errors()
     def register_block(self, block):
         """
         This function registers the forward hook. If user wants to register the hook

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -1,0 +1,251 @@
+# Standard Library
+import logging
+import os
+
+# Third Party
+import pytest
+from tests.zero_code_change.test_mxnet_gluon_integration import train_model
+
+# First Party
+from smdebug.core.error_handling_agent import BASE_ERROR_MESSAGE
+from smdebug.core.logger import DuplicateLogFilter, get_logger
+from smdebug.core.utils import error_handling_agent
+from smdebug.mxnet import Hook
+from smdebug.mxnet.collection import CollectionKeys
+from smdebug.pytorch.singleton_utils import del_hook
+
+
+@pytest.fixture
+def mxnet_callback_error_message(error_handling_message):
+    return error_handling_message.format("PyTorch callback error")
+
+
+@pytest.fixture
+def register_block_error_message(error_handling_message):
+    return error_handling_message.format("register block error")
+
+
+@pytest.fixture
+def hook_class_with_mxnet_callback_error(out_dir, mxnet_callback_error_message):
+    class HookWithBadMXNetCallback(Hook):
+        """
+        Hook subclass with error callback called directly from MXNet at regular intervals in
+        training.
+        """
+
+        def __init__(self, mxnet_error_message=mxnet_callback_error_message, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.mxnet_callback_error_message = mxnet_error_message
+
+        @error_handling_agent.catch_smdebug_errors()
+        def forward_hook(self, block, inputs, outputs):
+            """
+            Override the Hook's forward_hook callback to fail immediately.
+            """
+            raise RuntimeError(self.mxnet_callback_error_message)
+
+        @classmethod
+        def create_from_json_file(cls, json_file_path=None):
+            return HookWithBadMXNetCallback(out_dir=out_dir)
+
+    return HookWithBadMXNetCallback
+
+
+@pytest.fixture
+def hook_class_with_register_block_error(out_dir, register_block_error_message):
+    class HookWithBadRegisterBlock(Hook):
+        """
+        Hook subclass with faulty `register_block` function called directly from PyTorch
+        """
+
+        def __init__(
+            self, torch_register_block_error_message=register_block_error_message, *args, **kwargs
+        ):
+            super().__init__(*args, **kwargs)
+            self.register_block_error_message = torch_register_block_error_message
+
+        @error_handling_agent.catch_smdebug_errors()
+        def register_block(self, block):
+            """
+            Override the Hook's register_block function to fail immediately. This simulates a failure to register
+            the MXNet callbacks.
+            """
+            raise RuntimeError(self.register_block_error_message)
+
+        @classmethod
+        def create_from_json_file(cls, json_file_path=None):
+            return HookWithBadRegisterBlock(out_dir=out_dir)
+
+    return HookWithBadRegisterBlock
+
+
+@pytest.fixture
+def hook_class_with_mxnet_callback_and_register_block_error(
+    out_dir, hook_class_with_mxnet_callback_error, hook_class_with_register_block_error
+):
+    class HookWithBadMXNetCallbackAndRegisterBlock(
+        hook_class_with_mxnet_callback_error, hook_class_with_register_block_error
+    ):
+        """
+        Hook subclass with error callbacks called from MXNet.
+
+        Due to the ordering, the first callback to error is the `register_block` callback.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        @classmethod
+        def create_from_json_file(cls, json_file_path=None):
+            return HookWithBadMXNetCallbackAndRegisterBlock(out_dir=out_dir)
+
+    return HookWithBadMXNetCallbackAndRegisterBlock
+
+
+@pytest.fixture
+def hook_class_with_mxnet_callback_error_and_custom_debugger_configuration(
+    out_dir, custom_configuration_error_message, hook_class_with_mxnet_callback_error
+):
+    class HookWithBadMXNetCallbackAndCustomDebuggerConfiguration(
+        hook_class_with_mxnet_callback_error
+    ):
+        """
+        Hook subclass that extends off of the MXNet callback error subclass above to return a hook with a
+        custom debugger configuration. Thus, any errors thrown should not be caught by the error handling agent.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(
+                mxnet_error_message=custom_configuration_error_message, *args, **kwargs
+            )
+
+        @classmethod
+        def create_from_json_file(cls, json_file_path=None):
+            return HookWithBadMXNetCallbackAndCustomDebuggerConfiguration(
+                out_dir=out_dir, include_collections=[CollectionKeys.ALL]
+            )
+
+    return HookWithBadMXNetCallbackAndCustomDebuggerConfiguration
+
+
+@pytest.fixture(autouse=True)
+def set_up_logging_and_error_handling_agent(out_dir, stack_trace_filepath):
+    """
+    Set up each test to:
+        - Add a logging handler to write all logs to a file (which will be used to verify caught errors in the tests)
+        - Remove the duplicate logging filter
+        - Reset the error handling agent after the test so that smdebug is reenabled.
+    """
+    old_create_from_json = Hook.create_from_json_file
+    del_hook()
+
+    logger = get_logger()
+    os.makedirs(out_dir)
+    file_handler = logging.FileHandler(filename=stack_trace_filepath)
+    logger.addHandler(file_handler)
+    duplicate_log_filter = None
+    for log_filter in logger.filters:
+        if isinstance(log_filter, DuplicateLogFilter):
+            duplicate_log_filter = log_filter
+            break
+    logger.removeFilter(duplicate_log_filter)
+
+    yield
+
+    Hook.create_from_json_file = old_create_from_json
+    error_handling_agent.disable_smdebug = False
+    error_handling_agent.hook = None
+
+    logger.removeHandler(file_handler)
+    logger.addFilter(duplicate_log_filter)
+
+
+@pytest.mark.parametrize(
+    "hook_type",
+    ["mxnet_callback_error", "register_block_error", "mxnet_callback_and_register_block_error"],
+)
+def test_pytorch_error_handling(
+    hook_type,
+    hook_class_with_mxnet_callback_error,
+    hook_class_with_register_block_error,
+    hook_class_with_mxnet_callback_and_register_block_error,
+    out_dir,
+    stack_trace_filepath,
+    mxnet_callback_error_message,
+    register_block_error_message,
+):
+    """
+    Test that an error thrown by an smdebug function is caught and logged correctly by the error handling agent. This
+    test has three test cases:
+
+    mxnedt_callback_error: The MXNet hook's `forward_hook` is overridden to always fail. The error handling agent should
+    catch this error and log it once, and then disable smdebug for the rest of training.
+
+    register_block_error: The MXNet hook's `register_block` is overridden to always fail. The error handling
+    agent should catch this error and log it once, and then disable smdebug for the rest of training.
+
+    mxnet_callback_and_register_block_error: Both the `forward_hook` and `register_block` functions are overridden to always
+    fail. However, the `register_block` function is called first, so the error handling agent should only catch that
+    error. Then because smdebug is disabled, the error raised by `forward_hook` should not be caught because the function
+    shouldn't be even be called in the first place.
+
+    Each hook needs to be initialized during its corresponding test, because the error handling agent is configured
+    to a hook during the hook initialization.
+    """
+    assert error_handling_agent.disable_smdebug is False
+
+    if hook_type == "mxnet_callback_error":
+        hook_class = hook_class_with_mxnet_callback_error
+        error_message = mxnet_callback_error_message
+    elif hook_type == "register_block_error":
+        hook_class = hook_class_with_register_block_error
+        error_message = register_block_error_message
+    else:
+        hook_class = hook_class_with_mxnet_callback_and_register_block_error
+        error_message = (
+            register_block_error_message
+        )  # only `register_block` should error and get caught
+
+    Hook.create_from_json_file = hook_class.create_from_json_file
+
+    train_model()
+
+    assert error_handling_agent.disable_smdebug is True
+    with open(stack_trace_filepath) as logs:
+        stack_trace_logs = logs.read()
+
+        # check that one error was caught
+        assert stack_trace_logs.count(BASE_ERROR_MESSAGE) == 1
+
+        # check that the right error was caught (printed twice for each time caught)
+        assert stack_trace_logs.count(error_message) == 2
+
+        # `forward_hook` should not have errored if `register_block` already errored.
+        if hook_type == "mxnet_callback_and_register_block_error":
+            assert mxnet_callback_error_message not in stack_trace_logs
+
+
+def test_non_default_smdebug_configuration(
+    out_dir,
+    hook_class_with_mxnet_callback_error_and_custom_debugger_configuration,
+    custom_configuration_error_message,
+    stack_trace_filepath,
+):
+    """
+    Test that the error handling agent does not catch errors when a custom smdebug configuration of smdebug is used.
+
+    Each hook needs to be initialized during its corresponding test, because the error handling agent is configured
+    to a hook during the hook initialization.
+    """
+    Hook.create_from_json_file = (
+        hook_class_with_mxnet_callback_error_and_custom_debugger_configuration.create_from_json_file
+    )
+
+    # Verify the correct error gets thrown and doesnt get caught.
+    with pytest.raises(RuntimeError, match=custom_configuration_error_message):
+        train_model()
+    assert error_handling_agent.disable_smdebug is False
+    with open(stack_trace_filepath) as logs:
+        stack_trace_logs = logs.read()
+        assert stack_trace_logs.count(BASE_ERROR_MESSAGE) == 0
+        assert stack_trace_logs.count(custom_configuration_error_message) == 0

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 # Third Party
+import mxnet
 import pytest
 from tests.zero_code_change.test_mxnet_gluon_integration import train_model
 
@@ -135,9 +136,16 @@ def set_up_logging_and_error_handling_agent(out_dir, stack_trace_filepath):
         - Add a logging handler to write all logs to a file (which will be used to verify caught errors in the tests)
         - Remove the duplicate logging filter
         - Reset the error handling agent after the test so that smdebug is reenabled.
+        - Reset the cached smdebug hook in the MXNet framework
     """
     old_create_from_json = Hook.create_from_json_file
     del_hook()
+
+    global global_smdebug_hook
+    global global_hook_initialized
+
+    mxnet.gluon.block.global_smdebug_hook = None
+    mxnet.gluon.block.global_hook_initialized = False
 
     logger = get_logger()
     os.makedirs(out_dir)

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -33,7 +33,7 @@ def hook_class_with_mxnet_callback_error(out_dir, mxnet_callback_error_message):
             self.mxnet_callback_error_message = mxnet_error_message
 
         @error_handling_agent.catch_smdebug_errors()
-        def forward_pre_hook(self, block, inputs):
+        def forward_hook(self, block, inputs, outputs):
             """
             Override the Hook's forward_pre_hook callback to fail immediately.
             """

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -12,7 +12,7 @@ from smdebug.core.logger import DuplicateLogFilter, get_logger
 from smdebug.core.utils import error_handling_agent
 from smdebug.mxnet import Hook
 from smdebug.mxnet.collection import CollectionKeys
-from smdebug.pytorch.singleton_utils import del_hook
+from smdebug.mxnet.singleton_utils import del_hook
 
 
 @pytest.fixture

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -164,7 +164,7 @@ def set_up_logging_and_error_handling_agent(out_dir, stack_trace_filepath):
     "hook_type",
     ["mxnet_callback_error", "register_block_error", "mxnet_callback_and_register_block_error"],
 )
-def test_pytorch_error_handling(
+def test_mxnet_error_handling(
     hook_type,
     hook_class_with_mxnet_callback_error,
     hook_class_with_register_block_error,

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -33,7 +33,7 @@ def hook_class_with_mxnet_callback_error(out_dir, mxnet_callback_error_message):
             self.mxnet_callback_error_message = mxnet_error_message
 
         @error_handling_agent.catch_smdebug_errors()
-        def forward_pre_hook(self, block):
+        def forward_pre_hook(self, block, inputs):
             """
             Override the Hook's forward_pre_hook callback to fail immediately.
             """

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -129,7 +129,7 @@ def test_non_default_smdebug_configuration(
     )
 
     # Verify the correct error gets thrown and doesnt get caught.
-    with pytest.raises(RuntimeError, match=custom_configuration_error_message):
+    with pytest.raises(ValueError, match=custom_configuration_error_message):
         train_model()
 
     assert error_handling_agent.disable_smdebug is False

--- a/tests/zero_code_change/test_mxnet_error_handling_agent.py
+++ b/tests/zero_code_change/test_mxnet_error_handling_agent.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 # Third Party
-import mxnet
 import pytest
 from tests.zero_code_change.test_mxnet_gluon_integration import train_model
 
@@ -18,12 +17,7 @@ from smdebug.mxnet.singleton_utils import del_hook
 
 @pytest.fixture
 def mxnet_callback_error_message(error_handling_message):
-    return error_handling_message.format("PyTorch callback error")
-
-
-@pytest.fixture
-def register_block_error_message(error_handling_message):
-    return error_handling_message.format("register block error")
+    return error_handling_message.format("MXNet callback error")
 
 
 @pytest.fixture
@@ -39,9 +33,9 @@ def hook_class_with_mxnet_callback_error(out_dir, mxnet_callback_error_message):
             self.mxnet_callback_error_message = mxnet_error_message
 
         @error_handling_agent.catch_smdebug_errors()
-        def forward_hook(self, block, inputs, outputs):
+        def forward_pre_hook(self, block):
             """
-            Override the Hook's forward_hook callback to fail immediately.
+            Override the Hook's forward_pre_hook callback to fail immediately.
             """
             raise RuntimeError(self.mxnet_callback_error_message)
 
@@ -50,57 +44,6 @@ def hook_class_with_mxnet_callback_error(out_dir, mxnet_callback_error_message):
             return HookWithBadMXNetCallback(out_dir=out_dir)
 
     return HookWithBadMXNetCallback
-
-
-@pytest.fixture
-def hook_class_with_register_block_error(out_dir, register_block_error_message):
-    class HookWithBadRegisterBlock(Hook):
-        """
-        Hook subclass with faulty `register_block` function called directly from PyTorch
-        """
-
-        def __init__(
-            self, torch_register_block_error_message=register_block_error_message, *args, **kwargs
-        ):
-            super().__init__(*args, **kwargs)
-            self.register_block_error_message = torch_register_block_error_message
-
-        @error_handling_agent.catch_smdebug_errors()
-        def register_block(self, block):
-            """
-            Override the Hook's register_block function to fail immediately. This simulates a failure to register
-            the MXNet callbacks.
-            """
-            raise RuntimeError(self.register_block_error_message)
-
-        @classmethod
-        def create_from_json_file(cls, json_file_path=None):
-            return HookWithBadRegisterBlock(out_dir=out_dir)
-
-    return HookWithBadRegisterBlock
-
-
-@pytest.fixture
-def hook_class_with_mxnet_callback_and_register_block_error(
-    out_dir, hook_class_with_mxnet_callback_error, hook_class_with_register_block_error
-):
-    class HookWithBadMXNetCallbackAndRegisterBlock(
-        hook_class_with_mxnet_callback_error, hook_class_with_register_block_error
-    ):
-        """
-        Hook subclass with error callbacks called from MXNet.
-
-        Due to the ordering, the first callback to error is the `register_block` callback.
-        """
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-        @classmethod
-        def create_from_json_file(cls, json_file_path=None):
-            return HookWithBadMXNetCallbackAndRegisterBlock(out_dir=out_dir)
-
-    return HookWithBadMXNetCallbackAndRegisterBlock
 
 
 @pytest.fixture
@@ -136,10 +79,11 @@ def set_up_logging_and_error_handling_agent(out_dir, stack_trace_filepath):
         - Add a logging handler to write all logs to a file (which will be used to verify caught errors in the tests)
         - Remove the duplicate logging filter
         - Reset the error handling agent after the test so that smdebug is reenabled.
-        - Reset the cached smdebug hook in the MXNet framework
     """
     old_create_from_json = Hook.create_from_json_file
     del_hook()
+
+    import mxnet
 
     global global_smdebug_hook
     global global_hook_initialized
@@ -168,71 +112,6 @@ def set_up_logging_and_error_handling_agent(out_dir, stack_trace_filepath):
     logger.addFilter(duplicate_log_filter)
 
 
-@pytest.mark.parametrize(
-    "hook_type",
-    ["mxnet_callback_error", "register_block_error", "mxnet_callback_and_register_block_error"],
-)
-def test_mxnet_error_handling(
-    hook_type,
-    hook_class_with_mxnet_callback_error,
-    hook_class_with_register_block_error,
-    hook_class_with_mxnet_callback_and_register_block_error,
-    out_dir,
-    stack_trace_filepath,
-    mxnet_callback_error_message,
-    register_block_error_message,
-):
-    """
-    Test that an error thrown by an smdebug function is caught and logged correctly by the error handling agent. This
-    test has three test cases:
-
-    mxnedt_callback_error: The MXNet hook's `forward_hook` is overridden to always fail. The error handling agent should
-    catch this error and log it once, and then disable smdebug for the rest of training.
-
-    register_block_error: The MXNet hook's `register_block` is overridden to always fail. The error handling
-    agent should catch this error and log it once, and then disable smdebug for the rest of training.
-
-    mxnet_callback_and_register_block_error: Both the `forward_hook` and `register_block` functions are overridden to always
-    fail. However, the `register_block` function is called first, so the error handling agent should only catch that
-    error. Then because smdebug is disabled, the error raised by `forward_hook` should not be caught because the function
-    shouldn't be even be called in the first place.
-
-    Each hook needs to be initialized during its corresponding test, because the error handling agent is configured
-    to a hook during the hook initialization.
-    """
-    assert error_handling_agent.disable_smdebug is False
-
-    if hook_type == "mxnet_callback_error":
-        hook_class = hook_class_with_mxnet_callback_error
-        error_message = mxnet_callback_error_message
-    elif hook_type == "register_block_error":
-        hook_class = hook_class_with_register_block_error
-        error_message = register_block_error_message
-    else:
-        hook_class = hook_class_with_mxnet_callback_and_register_block_error
-        error_message = (
-            register_block_error_message
-        )  # only `register_block` should error and get caught
-
-    Hook.create_from_json_file = hook_class.create_from_json_file
-
-    train_model()
-
-    assert error_handling_agent.disable_smdebug is True
-    with open(stack_trace_filepath) as logs:
-        stack_trace_logs = logs.read()
-
-        # check that one error was caught
-        assert stack_trace_logs.count(BASE_ERROR_MESSAGE) == 1
-
-        # check that the right error was caught (printed twice for each time caught)
-        assert stack_trace_logs.count(error_message) == 2
-
-        # `forward_hook` should not have errored if `register_block` already errored.
-        if hook_type == "mxnet_callback_and_register_block_error":
-            assert mxnet_callback_error_message not in stack_trace_logs
-
-
 def test_non_default_smdebug_configuration(
     out_dir,
     hook_class_with_mxnet_callback_error_and_custom_debugger_configuration,
@@ -252,8 +131,42 @@ def test_non_default_smdebug_configuration(
     # Verify the correct error gets thrown and doesnt get caught.
     with pytest.raises(RuntimeError, match=custom_configuration_error_message):
         train_model()
+
     assert error_handling_agent.disable_smdebug is False
     with open(stack_trace_filepath) as logs:
         stack_trace_logs = logs.read()
         assert stack_trace_logs.count(BASE_ERROR_MESSAGE) == 0
         assert stack_trace_logs.count(custom_configuration_error_message) == 0
+
+
+def test_mxnet_error_handling(
+    hook_class_with_mxnet_callback_error,
+    out_dir,
+    stack_trace_filepath,
+    mxnet_callback_error_message,
+):
+    """
+    Test that an error thrown by an smdebug function is caught and logged correctly by the error handling agent. This
+    test has one test case:
+
+    mxnet_callback_error: The MXNet hook's `forward_pre_hook` is overridden to always fail. The error handling agent should
+    catch this error and log it once, and then disable smdebug for the rest of training.
+
+    The hook needs to be initialized during its corresponding test, because the error handling agent is configured
+    to a hook during the hook initialization.
+    """
+    assert error_handling_agent.disable_smdebug is False
+
+    Hook.create_from_json_file = hook_class_with_mxnet_callback_error.create_from_json_file
+
+    train_model()
+
+    assert error_handling_agent.disable_smdebug is True
+    with open(stack_trace_filepath) as logs:
+        stack_trace_logs = logs.read()
+
+        # check that one error was caught
+        assert stack_trace_logs.count(BASE_ERROR_MESSAGE) == 1
+
+        # check that the right error was caught (printed twice for each time caught)
+        assert stack_trace_logs.count(mxnet_callback_error_message) == 2

--- a/tests/zero_code_change/test_mxnet_gluon_integration.py
+++ b/tests/zero_code_change/test_mxnet_gluon_integration.py
@@ -41,7 +41,23 @@ def fn_test(ctx, net, val_data):
     return metric.get()
 
 
-def train_model(net, epochs, ctx, learning_rate, momentum, train_data, val_data):
+def train_model():
+    # DEFAULT CONSTANTS
+    batch_size = 256
+    epochs = 1
+    momentum = 0.9
+    learning_rate = 0.1
+    mx.random.seed(128)
+    random.seed(12)
+    np.random.seed(2)
+
+    ctx = mx.cpu()
+    # Create a Gluon Model.
+    net = create_gluon_model()
+
+    # Start the training.
+    train_data, val_data = prepare_data(batch_size)
+
     # Collect all parameters from net and its children, then initialize them.
     net.initialize(mx.init.Xavier(magnitude=2.24), ctx=ctx)
     # Trainer is for updating parameters with gradient.
@@ -149,20 +165,6 @@ def validate():
 
 
 def test_integration_mxnet():
-    # DEFAULT CONSTANTS
-    batch_size = 256
-    epochs = 1
-    learning_rate = 0.1
-    mx.random.seed(128)
-    random.seed(12)
-    np.random.seed(2)
-
-    context = mx.cpu()
-    # Create a Gluon Model.
-    net = create_gluon_model()
-
-    # Start the training.
-    train_data, val_data = prepare_data(batch_size)
 
     json_file_contents = """
         {
@@ -178,17 +180,8 @@ def test_integration_mxnet():
             ]
         }
         """
-    with SagemakerSimulator(json_file_contents=json_file_contents) as sim:
-        train_model(
-            net=net,
-            epochs=epochs,
-            ctx=context,
-            learning_rate=learning_rate,
-            momentum=0.9,
-            train_data=train_data,
-            val_data=val_data,
-        )
-
+    with SagemakerSimulator(json_file_contents=json_file_contents) as _:
+        train_model()
         validate()
 
 

--- a/tests/zero_code_change/test_pytorch_error_handling_agent.py
+++ b/tests/zero_code_change/test_pytorch_error_handling_agent.py
@@ -305,7 +305,7 @@ def test_pytorch_error_handling(
         assert stack_trace_logs.count(error_message) == 2
 
         # `fhook` should not have errored if `register_module` already errored.
-        if hook_type == "keras_and_layer_callback_error":
+        if hook_type == "torch_callback_and_register_module_error":
             assert torch_callback_error_message not in stack_trace_logs
 
 


### PR DESCRIPTION
### Description of changes:
Add error handling for MXNet. Wrapped the `register_block`, `forward_hook` and `forward_pre_hook` functions, which get called directly from MXNet.

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
