### PR TITLE
Cache the output of is_framework_version_supported

### DIFF
--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import urllib.parse
 from enum import Enum
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List
 
@@ -638,6 +639,8 @@ def check_smmodelparallel_training():
     return _is_using_smmodelparallel
 
 
+# we need to compute the output of this fn only once since the framework type will remain constant during execution
+@lru_cache(maxsize=None)
 def is_framework_version_supported(framework_type):
     if framework_type == FRAMEWORK.PYTORCH:
         from smdebug.pytorch.utils import is_current_version_supported


### PR DESCRIPTION
### Description of changes:
- The value of `is_framework_version_supported` needs to be computed only once since version checks are expensive and the value of the framework during execution will not change.

### Testing

I have validated that this change reduces the perf impact of the function using `pyinstrument`.
See code below:

```
from torch.utils.smdebug import get_smdebug_hook

NUM_ITER = 10000

for i in range(NUM_ITER):
    hook = get_smdebug_hook()
```


Without change:

```
Program: test_smdebug_hook.py

1.300 <module>  <string>:1
   [4 frames hidden]  <string>, runpy
      1.300 _run_code  runpy.py:64
      └─ 1.300 <module>  test_smdebug_hook.py:1
         ├─ 0.782 get_smdebug_hook  torch/utils/smdebug.py:28
         │  ├─ 0.351 error_handling_agent  smdebug/core/error_handling_agent.py:99
         │  │  └─ 0.349 get_hook  smdebug/pytorch/singleton_utils.py:17
         │  │     ├─ 0.248 validate_training_job  smdebug/core/config_validator.py:65
         │  │     │  └─ 0.242 _validate_training_environment  smdebug/core/config_validator.py:25
         │  │     │     └─ 0.240 is_framework_version_supported  smdebug/core/utils.py:641
         │  │     │        └─ 0.238 is_current_version_supported  smdebug/pytorch/utils.py:91
         │  │     │           └─ 0.223 parse  packaging/version.py:49
         │  │     │                 [24 frames hidden]  packaging, <built-in>, <string>
```

With Change:

```
Program: test_smdebug_hook.py

1.021 <module>  <string>:1
   [4 frames hidden]  <string>, runpy
      1.021 _run_code  runpy.py:64
      └─ 1.021 <module>  test_smdebug_hook.py:1
         ├─ 0.519 get_smdebug_hook  torch/utils/smdebug.py:28
         │  ├─ 0.261 <module>  smdebug/__init__.py:2
         │  │  └─ 0.261 <module>  smdebug/core/collection.py:2
         │  │     └─ 0.261 <module>  smdebug/core/reduction_config.py:2
         │  │        └─ 0.260 <module>  smdebug/core/utils.py:2
         │  │           ├─ 0.193 <module>  smdistributed/modelparallel/torch/__init__.py:2
         │  │           │     [655 frames hidden]  smdistributed, smexperiments, pkg_res...
         │  │           ├─ 0.041 <module>  requests/__init__.py:8
         │  │           │     [122 frames hidden]  requests, urllib3, re, sre_compile, s...
         │  │           └─ 0.021 <module>  horovod/torch/__init__.py:17
         │  │                 [64 frames hidden]  horovod, psutil, <built-in>, collecti...
```

#### Style and formatting:

I have run `pre-commit install` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
