### PR TITLE
Handle Horovod Import Error Bug

### DIFF
--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -68,7 +68,8 @@ except (ImportError, ModuleNotFoundError):
 try:
     import horovod.torch as hvd
 
-    # This redudant import is necessary because horovod does not raise an ImportError if the library is not present
+    # This redundant import is necessary because horovod does not raise an ImportError if the library is not present
+    import torch  # noqa
 
     _hvd_imported = hvd
 except (ModuleNotFoundError, ImportError):

--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -68,6 +68,8 @@ except (ImportError, ModuleNotFoundError):
 try:
     import horovod.torch as hvd
 
+    # This redudant import is necessary because horovod does not raise an ImportError if the library is not present
+
     _hvd_imported = hvd
 except (ModuleNotFoundError, ImportError):
     try:


### PR DESCRIPTION
### Description of changes:
- `import horovod.torch as hvd` does not raise an ImportError if it is not present.
- We need to redundantly `import torch` to see if we're running in a env with pytorch present

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
