### PR TITLE
Update TF 2.6.0 Tests To Support Keras Breaking Changes

### DIFF
--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -21,7 +21,7 @@ TF_VERSION = version.parse(tf.__version__)
 def does_tf_support_mixed_precision_training():
     # The Keras mixed precision API is first available in TensorFlow 2.1.0
     # See: https://www.tensorflow.org/guide/mixed_precision
-    return TF_VERSION >= version.parse("2.1.0")
+    return TF_VERSION >= version.parse("2.1.0") and TF_VERSION < version.parse("2.6.0")
 
 
 def supported_tf_variables():

--- a/tests/tensorflow2/test_concat_layer.py
+++ b/tests/tensorflow2/test_concat_layer.py
@@ -1,7 +1,9 @@
 # Third Party
 import numpy as np
+import pytest
 from tensorflow.keras.layers import Concatenate, Dense
 from tensorflow.python.keras.models import Model
+from tests.tensorflow2.utils import is_tf_2_6
 
 # First Party
 import smdebug.tensorflow as smd
@@ -19,6 +21,9 @@ class MyModel(Model):
         return self.dense(x)
 
 
+@pytest.mark.skipif(
+    is_tf_2_6() is True, reason="Breaking Changes In TF 2.6.0 deprecates this feature"
+)
 def test_multiple_inputs(out_dir):
     my_model = MyModel()
     hook = smd.KerasHook(

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -472,10 +472,15 @@ def test_keras_fit(out_dir, tf_eager_mode, saveall):
     # can't save gradients in TF 2.x eager mode
     if saveall:  # save losses, metrics, weights, biases, scalar
         if tf_eager_mode:
-            if is_tf_2_2():
-                assert len(trial.tensor_names()) == 28
+            if is_tf_2_6():
+                num_tensors = 13
+            elif is_tf_2_2():
+                num_tensors = 28
+            elif is_tf_2_3():
+                num_tensors = 21
             else:
-                assert len(trial.tensor_names()) == (21 if is_tf_2_3() else 14)
+                num_tensors = 14
+            assert len(trial.tensor_names()) == num_tensors
             assert len(trial.tensor_names(collection=CollectionKeys.INPUTS)) == (
                 1 if is_tf_2_2() else 0
             )

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -482,10 +482,10 @@ def test_keras_fit(out_dir, tf_eager_mode, saveall):
                 num_tensors = 14
             assert len(trial.tensor_names()) == num_tensors
             assert len(trial.tensor_names(collection=CollectionKeys.INPUTS)) == (
-                1 if is_tf_2_2() else 0
+                1 if is_tf_2_2() and not is_tf_2_6() else 0
             )
             assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == (
-                2 if is_tf_2_2() else 0
+                2 if is_tf_2_2() and not is_tf_2_6() else 0
             )
         else:
             assert len(trial.tensor_names()) == 21
@@ -589,7 +589,7 @@ def test_include_regex(out_dir, tf_eager_mode):
 
     tr = create_trial_fast_refresh(out_dir)
     tnames = tr.tensor_names(collection="custom_coll")
-    assert len(tnames) == (12 if is_tf_2_2() else 4)
+    assert len(tnames) == (12 if is_tf_2_2() and not is_tf_2_6() else 4)
     for tname in tnames:
         assert tr.tensor(tname).value(0) is not None
 

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -617,6 +617,7 @@ def test_layer_names(out_dir, tf_eager_mode):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(is_tf_2_6(), reason="Unsupported with TF 2.6 due to keras breaking changes")
 def test_regex_filtering_for_default_collections(out_dir):
     hook = smd.KerasHook(
         out_dir,
@@ -800,6 +801,8 @@ def test_keras_fit_pure_eager(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == (2 if is_tf_2_2() else 0)
 
 
+@pytest.mark.slow
+@pytest.mark.skipif(is_tf_2_6(), reason="Unsupported with TF 2.6 due to keras breaking changes")
 def test_model_inputs_and_outputs(out_dir, tf_eager_mode):
     # explicitly save INPUTS and OUTPUTS
     include_collections = [CollectionKeys.INPUTS, CollectionKeys.OUTPUTS]

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -804,8 +804,12 @@ def test_keras_fit_pure_eager(out_dir, tf_eager_mode):
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES)) == 5
-    assert len(trial.tensor_names(collection=CollectionKeys.INPUTS)) == (1 if is_tf_2_2() else 0)
-    assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == (2 if is_tf_2_2() else 0)
+    assert len(trial.tensor_names(collection=CollectionKeys.INPUTS)) == (
+        1 if is_tf_2_2() and not is_tf_2_6() else 0
+    )
+    assert len(trial.tensor_names(collection=CollectionKeys.OUTPUTS)) == (
+        2 if is_tf_2_2() and not is_tf_2_6() else 0
+    )
 
 
 @pytest.mark.slow

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -727,7 +727,9 @@ def test_include_collections(out_dir, tf_eager_mode):
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
     if tf_eager_mode:
-        if is_tf_2_2():
+        if is_tf_2_6():
+            assert len(trial.tensor_names()) == 12
+        elif is_tf_2_2():
             assert len(trial.tensor_names()) == 16
         else:
             assert len(trial.tensor_names()) == (12 if is_tf_2_3() else 13)
@@ -793,7 +795,12 @@ def test_keras_fit_pure_eager(out_dir, tf_eager_mode):
     helper_keras_fit(trial_dir=out_dir, hook=hook, eager=tf_eager_mode, run_eagerly=True)
 
     trial = smd.create_trial(path=out_dir)
-    assert len(trial.tensor_names()) == (27 if is_tf_2_2() else 13)
+    if is_tf_2_6():
+        assert len(trial.tensor_names()) == 12
+    elif is_tf_2_2():
+        assert len(trial.tensor_names()) == 27
+    else:
+        assert len(trial.tensor_names()) == 13
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
     assert len(trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES)) == 5

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -17,7 +17,7 @@ import pytest
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 from tests.constants import TEST_DATASET_S3_PATH
-from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3
+from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3, is_tf_2_6
 from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.utils import use_s3_datasets, verify_shapes
 
@@ -227,7 +227,13 @@ def test_keras_gradtape(out_dir, saveall):
 
     trial = smd.create_trial(path=out_dir)
     if saveall:  # save losses, metrics, weights, biases
-        assert len(trial.tensor_names()) == (25 if is_tf_2_2() else 15)
+        if is_tf_2_6():
+            num_tensors = 15
+        elif is_tf_2_2():
+            num_tensors = 25
+        else:
+            num_tensors = 15
+        assert len(trial.tensor_names()) == num_tensors
         assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES)) == 5
@@ -306,8 +312,13 @@ def test_gradtape_include_regex(out_dir):
 
     tr = create_trial_fast_refresh(out_dir)
     tnames = tr.tensor_names(collection="custom_coll")
-
-    assert len(tnames) == (12 if is_tf_2_2() else 8)
+    if is_tf_2_6():
+        num_tensors = 8
+    elif is_tf_2_2():
+        num_tensors = 12
+    else:
+        num_tensors = 8
+    assert len(tnames) == num_tensors
     for tname in tnames:
         assert tr.tensor(tname).value(0) is not None
 
@@ -375,7 +386,13 @@ def test_gradtape_include_collections(out_dir):
 
     trial = smd.create_trial(path=out_dir)
     # can't save gradients in TF 2.x
-    assert len(trial.tensor_names()) == (16 if is_tf_2_2() else 15)
+    if is_tf_2_6():
+        num_tensors = 15
+    elif is_tf_2_2():
+        num_tensors = 16
+    else:
+        num_tensors = 15
+    assert len(trial.tensor_names()) == num_tensors
     assert len(trial.tensor_names(collection=CollectionKeys.GRADIENTS)) == 4
     assert len(trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES)) == 5
     assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
@@ -420,7 +437,13 @@ def test_gradtape_persistent(out_dir, saveall):
 
     trial = smd.create_trial(path=out_dir)
     if saveall:  # save losses, metrics, weights, biases
-        assert len(trial.tensor_names()) == (25 if is_tf_2_2() else 15)
+        if is_tf_2_6():
+            num_tensors = 15
+        elif is_tf_2_2():
+            num_tensors = 25
+        else:
+            num_tensors = 15
+        assert len(trial.tensor_names()) == num_tensors
         assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
         assert len(trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES)) == 5

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -165,7 +165,9 @@ def exhaustive_check(trial_dir, include_workers="one", eager=True):
     if include_workers == "all":
         assert len(tr.workers()) == strategy.num_replicas_in_sync
         if eager:
-            if is_tf_2_2():
+            if is_tf_2_6():
+                assert len(tr.tensor_names()) == 15
+            elif is_tf_2_2():
                 assert len(tr.tensor_names()) == (6 + 1 + 2 + 5 + 1 + 6 + 2)
                 # 6 weights, 1 loss, 2 metrics, 5 optimizer variables, 6 gradients, 2 outputs for Tf 2.2, 1 scalar
             else:

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -393,7 +393,13 @@ def test_include_regex(out_dir, tf_eager_mode, workers):
     tnames = tr.tensor_names(collection="custom_coll")
 
     if tf_eager_mode:
-        assert len(tnames) == (12 if is_tf_2_2() else 4)
+        if is_tf_2_6():
+            num_tensors = 4
+        elif is_tf_2_2():
+            num_tensors = 12
+        else:
+            num_tensors = 4
+        assert len(tnames) == num_tensors
     else:
         assert len(tnames) == 4 + 3 * strategy.num_replicas_in_sync
     for tname in tnames:

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -262,7 +262,9 @@ def test_save_all(out_dir, tf_eager_mode, workers):
     tr = create_trial_fast_refresh(out_dir)
     print(tr.tensor_names())
     if tf_eager_mode:
-        if is_tf_2_2():
+        if is_tf_2_6():
+            assert len(tr.tensor_names()) == 15
+        elif is_tf_2_2():
             assert len(tr.tensor_names()) == (
                 6 + 2 + 1 + 5 + 1 + 1 + 2 + 8 + 8 if is_tf_2_2() else 6 + 3 + 1 + 5 + 1
             )

--- a/tests/tensorflow2/test_keras_mirrored.py
+++ b/tests/tensorflow2/test_keras_mirrored.py
@@ -11,7 +11,7 @@ import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 from tensorflow.python.client import device_lib
 from tests.core.utils import verify_files
-from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3
+from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_3, is_tf_2_6
 from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.utils import verify_shapes
 
@@ -448,7 +448,9 @@ def test_clash_with_tb_callback(out_dir):
         add_callbacks=["tensorboard"],
     )
     tr = create_trial_fast_refresh(out_dir)
-    if is_tf_2_2():
+    if is_tf_2_6():
+        assert len(tr.tensor_names()) == 10
+    elif is_tf_2_2():
         assert len(tr.tensor_names()) == 16
     else:
         assert len(tr.tensor_names()) == (10 if is_tf_2_3() else 11)

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -1,4 +1,5 @@
 # Third Party
+import pytest
 import tensorflow as tf
 from tensorflow.keras.layers import BatchNormalization, Conv2D, Dense, Flatten
 from tensorflow.keras.models import Model
@@ -50,6 +51,10 @@ class MyModel(Model):
         return self.second(x)
 
 
+@pytest.mark.skipif(
+    is_tf_2_2() is False and is_tf_2_6() is False,
+    reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
+)
 def test_subclassed_model(out_dir):
     # Download and load MNIST dataset.
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data("MNIST-data")

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -3,7 +3,7 @@ import pytest
 import tensorflow as tf
 from tensorflow.keras.layers import BatchNormalization, Conv2D, Dense, Flatten
 from tensorflow.keras.models import Model
-from tests.tensorflow2.utils import is_tf_2_2
+from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_6
 
 # First Party
 import smdebug.tensorflow as smd

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -52,7 +52,7 @@ class MyModel(Model):
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False and is_tf_2_6() is False,
+    is_tf_2_2() is False and is_tf_2_6() is True,
     reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
 )
 def test_subclassed_model(out_dir):

--- a/tests/tensorflow2/test_model_subclassing.py
+++ b/tests/tensorflow2/test_model_subclassing.py
@@ -52,7 +52,7 @@ class MyModel(Model):
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False and is_tf_2_6() is True,
+    is_tf_2_2() is False or is_tf_2_6() is True,
     reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
 )
 def test_subclassed_model(out_dir):

--- a/tests/tensorflow2/test_support_dicts.py
+++ b/tests/tensorflow2/test_support_dicts.py
@@ -32,7 +32,7 @@ def create_model():
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False and is_tf_2_6() is True,
+    is_tf_2_2() is False or is_tf_2_6() is True,
     reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
 )
 def test_support_dicts(out_dir):

--- a/tests/tensorflow2/test_support_dicts.py
+++ b/tests/tensorflow2/test_support_dicts.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from tests.tensorflow2.utils import is_tf_2_2
+from tests.tensorflow2.utils import is_tf_2_2, is_tf_2_6
 
 # First Party
 import smdebug.tensorflow as smd
@@ -32,7 +32,7 @@ def create_model():
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False,
+    is_tf_2_2() is False and is_tf_2_6() is False,
     reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
 )
 def test_support_dicts(out_dir):

--- a/tests/tensorflow2/test_support_dicts.py
+++ b/tests/tensorflow2/test_support_dicts.py
@@ -32,7 +32,7 @@ def create_model():
 
 
 @pytest.mark.skipif(
-    is_tf_2_2() is False and is_tf_2_6() is False,
+    is_tf_2_2() is False and is_tf_2_6() is True,
     reason="Feature to save model inputs and outputs was first added for TF 2.2.0",
 )
 def test_support_dicts(out_dir):

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -22,6 +22,12 @@ def is_tf_2_2():
     return False
 
 
+def is_tf_2_6():
+    if TF_VERSION >= version.parse("2.6.0"):
+        return True
+    return False
+
+
 def is_tf_2_3():
     if TF_VERSION == version.parse("2.3.0"):
         return True

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -32,6 +32,12 @@ def is_tf_version_greater_than_2_4_x():
     return version.parse("2.4.0") <= TF_VERSION
 
 
+def is_tf_2_6():
+    if TF_VERSION == version.parse("2.6.0"):
+        return True
+    return False
+
+
 class ModelType(Enum):
     SEQUENTIAL = 0
     FUNCTIONAL = 1


### PR DESCRIPTION
### Description of changes:
- Keras features are no longer supported due to breaking changes introduced in TF 2.6.0 
- Updating tests to account for that

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
