### PR TITLE
Extended Debugger reductions and fixed some bugs

### DIFF
--- a/smdebug/core/hook.py
+++ b/smdebug/core/hook.py
@@ -512,7 +512,7 @@ class BaseHook:
             return []
         return self._get_main_writer()
 
-    def _maybe_get_tb_writer(self) -> Optional[FileWriter]:
+    def _maybe_get_tb_writer(self, subfolder=None) -> Optional[FileWriter]:
         """ Returns a FileWriter object if `hook.tensorboard_dir` has been specified, else None.
 
         Creates a writer if does not exist.
@@ -520,22 +520,25 @@ class BaseHook:
         if not self.tensorboard_dir:
             return None
 
-        if self.mode in self.tb_writers:
-            assert self.tb_writers[self.mode] is not None
+        if subfolder == None:
+            subfolder = self.mode
+
+        if subfolder in self.tb_writers:
+            assert self.tb_writers[subfolder] is not None
             # would be there if set_mode was called
-            return self.tb_writers[self.mode]
+            return self.tb_writers[subfolder]
         else:
             # s = self.step
             # if s < 0: s = 0
-            self.tb_writers[self.mode] = FileWriter(
+            self.tb_writers[subfolder] = FileWriter(
                 trial_dir=self.tensorboard_dir,
                 step=self.step,
                 worker=get_tb_worker(),
                 write_checksum=True,
                 wtype="tensorboard",
-                mode=self.mode,
+                mode=subfolder,
             )
-            return self.tb_writers[self.mode]
+            return self.tb_writers[subfolder]
 
     def _close_tb_writer(self):
         if self.dry_run:
@@ -660,16 +663,32 @@ class BaseHook:
         collection_file_name = f"{self.worker}_collections.json"
         self.collection_manager.export(self.out_dir, collection_file_name)
 
-    def _get_reduction_tensor_name(self, tensor_name, reduction_name, abs):
-        return get_reduction_tensor_name(tensor_name, reduction_name, abs, remove_colon_index=True)
+    def _get_reduction_tensor_name(self, tensor_name, reduction_name, abs, collection_name=""):
+        return get_reduction_tensor_name(
+            tensor_name,
+            reduction_name,
+            abs,
+            remove_colon_index=True,
+            collection_name=collection_name,
+        )
 
-    def _write_reduction(self, tensor_name, tensor_value, reduction_name, abs, tensor_ref=None):
-        reduction_tensor_name = self._get_reduction_tensor_name(tensor_name, reduction_name, abs)
+    def _write_reduction(
+        self, tensor_name, tensor_value, reduction_name, abs, tensor_ref=None, collection_name=""
+    ):
+        reduction_tensor_name = self._get_reduction_tensor_name(
+            tensor_name, reduction_name, abs, collection_name=collection_name
+        )
         try:
             tensor_data = self._get_reduction_of_data(
                 reduction_name, tensor_value, tensor_name, abs
             )
             self._write_raw_tensor_simple(reduction_tensor_name, tensor_data, tensor_ref=tensor_ref)
+            if abs:
+                reduction_name = "abs_" + reduction_name
+            tb_writer = self._maybe_get_tb_writer(subfolder=reduction_name)
+            if tb_writer:
+                scalar = self._make_numpy_array(tensor_data)
+                tb_writer.write_scalar_summary(reduction_tensor_name, scalar, self.step)
         except ValueError as e:
             self.logger.warning(
                 f"Could not compute reduction {reduction_name} of {tensor_name} due to {e}"
@@ -685,14 +704,24 @@ class BaseHook:
                 for reduction in reduction_list:
                     if (reduction, False) not in reductions_saved:
                         self._write_reduction(
-                            tensor_name, tensor_value, reduction, abs=False, tensor_ref=tensor_ref
+                            tensor_name,
+                            tensor_value,
+                            reduction,
+                            abs=False,
+                            tensor_ref=tensor_ref,
+                            collection_name=s_col.name,
                         )
                         reductions_saved.add((reduction, False))
             for reduction_list in (reduction_config.abs_reductions, reduction_config.abs_norms):
                 for reduction in reduction_list:
                     if (reduction, True) not in reductions_saved:
                         self._write_reduction(
-                            tensor_name, tensor_value, reduction, abs=True, tensor_ref=tensor_ref
+                            tensor_name,
+                            tensor_value,
+                            reduction,
+                            abs=True,
+                            tensor_ref=tensor_ref,
+                            collection_name=s_col.name,
                         )
                         reductions_saved.add((reduction, True))
 

--- a/smdebug/core/locations.py
+++ b/smdebug/core/locations.py
@@ -120,11 +120,14 @@ class TensorboardFileLocation(EventFileLocation):
 
     def get_file_location(self, base_dir=""):
         # when base_dir is empty it just returns the relative file path
-        if base_dir:
-            event_key_prefix = os.path.join(base_dir, self.mode.name)
+        if hasattr(self.mode, "name"):
+            subfolder = self.mode.name
         else:
-            event_key_prefix = os.path.join(self.type, self.mode.name)
-
+            subfolder = self.mode
+        if base_dir:
+            event_key_prefix = os.path.join(base_dir, subfolder)
+        else:
+            event_key_prefix = os.path.join(self.type, subfolder)
         return os.path.join(event_key_prefix, self.get_filename())
 
 

--- a/smdebug/core/reduction_config.py
+++ b/smdebug/core/reduction_config.py
@@ -103,10 +103,6 @@ class ReductionConfig:
                 continue
             raise ValueError("abs_reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
 
-        # if any([x not in ALLOWED_REDUCTIONS for x in self.reductions]):
-        #    raise ValueError("reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
-        # if any([x not in ALLOWED_REDUCTIONS for x in self.abs_reductions]):
-        #    raise ValueError("abs_reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
         if any([x not in ALLOWED_NORMS for x in self.norms]):
             raise ValueError("norms can only be one of " + ",".join(ALLOWED_NORMS))
         if any([x not in ALLOWED_NORMS for x in self.abs_norms]):

--- a/smdebug/core/reduction_config.py
+++ b/smdebug/core/reduction_config.py
@@ -3,13 +3,25 @@ import json
 from typing import Any, Dict
 
 # First Party
+from smdebug.analysis.utils import parse_bool
 from smdebug.core.logger import get_logger
 from smdebug.core.utils import split
 
 logger = get_logger()
 
 
-ALLOWED_REDUCTIONS = ["min", "max", "mean", "std", "variance", "sum", "prod"]
+ALLOWED_REDUCTIONS = [
+    "min",
+    "max",
+    "mean",
+    "std",
+    "variance",
+    "sum",
+    "prod",
+    "isnan",
+    "isinf",
+    "quantile",
+]
 ALLOWED_NORMS = ["l1", "l2"]
 REDUCTION_CONFIG_VERSION_NUM = "v0"
 ALLOWED_PARAMS = [
@@ -66,7 +78,7 @@ class ReductionConfig:
         self.abs_reductions = abs_reductions if abs_reductions is not None else []
         self.norms = norms if norms is not None else []
         self.abs_norms = abs_norms if abs_norms is not None else []
-        self.save_raw_tensor = save_raw_tensor
+        self.save_raw_tensor = parse_bool(save_raw_tensor, True)
         self.save_shape = save_shape
         ## DO NOT REMOVE, if you add anything here, please make sure that _check & from_json is updated accordingly
         self._check()
@@ -77,11 +89,24 @@ class ReductionConfig:
             raise ValueError(
                 "allowed params for reduction config can only be one of " + ",".join(ALLOWED_PARAMS)
             )
-
-        if any([x not in ALLOWED_REDUCTIONS for x in self.reductions]):
+        for index, reduction_allowed in enumerate(
+            [x in ALLOWED_REDUCTIONS for x in self.reductions]
+        ):
+            if reduction_allowed or self.reductions[index].startswith("quantile"):
+                continue
             raise ValueError("reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
-        if any([x not in ALLOWED_REDUCTIONS for x in self.abs_reductions]):
+
+        for index, reduction_allowed in enumerate(
+            [x in ALLOWED_REDUCTIONS for x in self.abs_reductions]
+        ):
+            if reduction_allowed or self.abs_reductions[index].startswith("quantile"):
+                continue
             raise ValueError("abs_reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
+
+        # if any([x not in ALLOWED_REDUCTIONS for x in self.reductions]):
+        #    raise ValueError("reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
+        # if any([x not in ALLOWED_REDUCTIONS for x in self.abs_reductions]):
+        #    raise ValueError("abs_reductions can only be one of " + ",".join(ALLOWED_REDUCTIONS))
         if any([x not in ALLOWED_NORMS for x in self.norms]):
             raise ValueError("norms can only be one of " + ",".join(ALLOWED_NORMS))
         if any([x not in ALLOWED_NORMS for x in self.abs_norms]):

--- a/smdebug/core/reductions.py
+++ b/smdebug/core/reductions.py
@@ -1,5 +1,6 @@
 # Standard Library
 import re
+import socket
 
 # Third Party
 import numpy as np
@@ -47,14 +48,10 @@ def get_reduction_tensor_name(
 ):
     # for frameworks other than TF, it makes sense to not have trailing :0, :1
     # but for TF, it makes sense to keep it consistent with TF traditional naming style
-    # tname = f"{reduction_name}/{tensorname}"
     tname = f"{tensorname}"
     if remove_colon_index:
         tname = re.sub(r":\d+", "", tname)
-    #    if abs:
-    #        tname = "abs_" + tname
-    # tname = REDUCTIONS_PREFIX + tname
-    tname = collection_name + "/reductions/" + tname
+    tname = collection_name + "/reductions/" + tname + "_" + socket.gethostname()
     return tname
 
 

--- a/smdebug/core/reductions.py
+++ b/smdebug/core/reductions.py
@@ -42,15 +42,19 @@ def get_basic_numpy_reduction(reduction_name, numpy_data):
     return None
 
 
-def get_reduction_tensor_name(tensorname, reduction_name, abs, remove_colon_index=True):
+def get_reduction_tensor_name(
+    tensorname, reduction_name, abs, remove_colon_index=True, collection_name="smdebug"
+):
     # for frameworks other than TF, it makes sense to not have trailing :0, :1
     # but for TF, it makes sense to keep it consistent with TF traditional naming style
-    tname = f"{reduction_name}/{tensorname}"
+    # tname = f"{reduction_name}/{tensorname}"
+    tname = f"{tensorname}"
     if remove_colon_index:
         tname = re.sub(r":\d+", "", tname)
-    if abs:
-        tname = "abs_" + tname
-    tname = REDUCTIONS_PREFIX + tname
+    #    if abs:
+    #        tname = "abs_" + tname
+    # tname = REDUCTIONS_PREFIX + tname
+    tname = collection_name + "/reductions/" + tname
     return tname
 
 

--- a/smdebug/pytorch/utils.py
+++ b/smdebug/pytorch/utils.py
@@ -19,14 +19,25 @@ def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
         return get_numpy_reduction(reduction_name, tensor_data, abs)
     if abs:
         tensor_data = torch.abs(tensor_data)
-
+    if reduction_name.startswith("quantile") and hasattr(torch, "quantile"):
+        f = getattr(torch, "quantile")
+        value = float(reduction_name.replace("quantile", "")[1]) / 100
+        op = f(tensor_data.float(), value)
+        return op
     if reduction_name in ALLOWED_REDUCTIONS:
         if reduction_name == "variance":
             reduction_name = "var"
-        assert hasattr(torch.Tensor, reduction_name)
-        f = getattr(torch.Tensor, reduction_name)
-        op = f(tensor_data)
-        return op
+        if hasattr(torch.Tensor, reduction_name):
+            f = getattr(torch.Tensor, reduction_name)
+            op = f(tensor_data.float())
+            if reduction_name == "isnan" or reduction_name == "isinf":
+                op = torch.sum(op)
+            return op
+        if hasattr(torch, reduction_name):
+            f = getattr(torch, reduction_name)
+            op = f(tensor_data)
+            op = torch.sum(op)
+            return op
     elif reduction_name in ALLOWED_NORMS:
         if reduction_name in ["l1", "l2"]:
             ord = int(reduction_name[1])
@@ -34,7 +45,7 @@ def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
             raise RuntimeError(
                 "Invalid normalization operation {0} for torch.Tensor".format(reduction_name)
             )
-        op = torch.norm(tensor_data, p=ord)
+        op = torch.norm(tensor_data.float(), p=ord)
         return op
     elif hasattr(torch, reduction_name):
         f = getattr(torch, reduction_name)


### PR DESCRIPTION
### Description of changes:
Extended smdebug's reductions to check for nan- and inf-values and to compute quantiles for PT tensors. Tensors are now also written out in Tensorboard format such that users can display all reductions for a specific tensor within the same visualization and visualizations will be grouped by Debugger collections.
Here is an example visualization:

![Screen Shot 2021-11-14 at 2 52 42 PM](https://user-images.githubusercontent.com/12165606/141701908-f7035682-ff3c-4b08-badc-e809a5286583.png)

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
