### PR TITLE
Compatibility with TF 2.7

### DIFF
--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -653,5 +653,8 @@ def is_framework_version_supported(framework_type):
         from smdebug.tensorflow.utils import is_current_version_supported
 
         return is_current_version_supported()
-    else:  # If framework is mxnet and XGBoost we will currently return True for all versions
+    # If framework is mxnet and XGBoost we will currently return True for all versions
+    elif framework_type in [FRAMEWORK.XGBOOST, FRAMEWORK.MXNET]:
         return True
+
+    raise Exception(f"No such framework type {framework_type}")

--- a/smdebug/pytorch/utils.py
+++ b/smdebug/pytorch/utils.py
@@ -13,6 +13,8 @@ from smdebug.core.reductions import get_numpy_reduction
 # Cached Pytorch Version
 PT_VERSION = version.parse(torch.__version__)
 
+SUPPORTED_PT_VERSION_THRESHOLD = version.parse("1.10.0")
+
 
 def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
     if isinstance(tensor_data, np.ndarray):
@@ -89,4 +91,4 @@ def is_pt_1_9():
 
 
 def is_current_version_supported(pytorch_version=torch.__version__):
-    return version.parse("1.5.0") <= version.parse(pytorch_version) < version.parse("1.10.0")
+    return version.parse("1.5.0") <= version.parse(pytorch_version) < SUPPORTED_PT_VERSION_THRESHOLD

--- a/smdebug/tensorflow/singleton_utils.py
+++ b/smdebug/tensorflow/singleton_utils.py
@@ -46,4 +46,7 @@ def get_hook(
             create_if_not_exists=create_if_not_exists,
         )
     else:
+        # we choose not to raise an exception, because sagemaker debugger is running
+        # on ALL training jobs by default, and we don't know when `get_hook()` is being called
+        # where it might fail to retrieve the hook
         return None

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -16,6 +16,7 @@ from smdebug.core.utils import error_handling_agent
 
 # Cached TF Version
 TF_VERSION = version.parse(tf.__version__)
+SUPPORTED_TF_VERSION_THRESHOLD = version.parse("2.8.0")
 
 
 def does_tf_support_mixed_precision_training():
@@ -440,4 +441,8 @@ def is_profiler_supported_for_tf_version():
 
 
 def is_current_version_supported(tf_version=tf.__version__):
-    return version.parse("1.15.0") <= version.parse(tf_version) < version.parse("2.7.0")
+    return version.parse("1.15.0") <= version.parse(tf_version) < SUPPORTED_TF_VERSION_THRESHOLD
+
+
+def get_current_version():
+    return version.parse(tf.__version__)

--- a/tests/pytorch/test_get_hook.py
+++ b/tests/pytorch/test_get_hook.py
@@ -1,10 +1,29 @@
-# Standard Library
-# Third Party
 import pytest
+import torch
 from numpy import percentile
 from tests.utils import SagemakerSimulator, Timer, is_running_in_codebuild
 from torch.utils.smdebug import get_smdebug_hook
 
+from smdebug.core.utils import FRAMEWORK, is_framework_version_supported
+
+
+def test_did_you_forget_to_update_the_supported_framework_version():
+    """
+    This test is designed to save you 2 days of debugging time in case you're new
+    to the codebase.
+
+    One of the side-effects of not updating LATEST_SUPPORTED_TF_VERSION with the
+    version of Tensorflow you're trying to release for is that `smdebug.tensorflow.get_hook()` is going to return `None`
+    and many tests will fail.
+
+    This is just to make you aware of the problem.
+    """
+    if not is_framework_version_supported(FRAMEWORK.PYTORCH):
+        raise Exception(
+            "You are running against an unsupported version of Pytorch... apparently."
+            " Please update `smdebug.pytorch.utils.SUPPORTED_TF_VERSION_THRESHOLD`"
+            f" if you are trying to release sagemaker-debugger for the next version of pytorch ({torch.__version__})."
+        )
 
 @pytest.mark.skipif(
     is_running_in_codebuild() is False,

--- a/tests/tensorflow/keras/test_keras.py
+++ b/tests/tensorflow/keras/test_keras.py
@@ -12,6 +12,7 @@ from smdebug.core.access_layer import has_training_ended
 from smdebug.core.collection import CollectionKeys
 from smdebug.core.modes import ModeKeys
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
+from smdebug.core.utils import FRAMEWORK, is_framework_version_supported
 from smdebug.exceptions import TensorUnavailableForStep
 from smdebug.tensorflow import ReductionConfig, SaveConfig
 from smdebug.tensorflow.keras import KerasHook
@@ -133,6 +134,25 @@ def train_model(
             model.predict(x_test[:100], callbacks=hooks, verbose=0)
 
     hook._cleanup()
+
+
+def test_did_you_forget_to_update_the_supported_framework_version():
+    """
+    This test is designed to save you 2 days of debugging time in case you're new
+    to the codebase.
+
+    One of the side-effects of not updating LATEST_SUPPORTED_TF_VERSION with the
+    version of Tensorflow you're trying to release for is that `smdebug.tensorflow.get_hook()` is going to return `None`
+    and many tests will fail.
+
+    This is just to make you aware of the problem.
+    """
+    if not is_framework_version_supported(FRAMEWORK.PYTORCH):
+        raise Exception(
+            "You are running against an unsupported version of Tensorflow..."
+            " Please update `smdebug.tensorflow.utils.SUPPORTED_TF_VERSION_THRESHOLD`"
+            f" if you are trying to release sagemaker-debugger for the next version of tensorflow ({tf.__version__})."
+        )
 
 
 @pytest.mark.skip(

--- a/tests/tensorflow/keras/test_keras_mirrored.py
+++ b/tests/tensorflow/keras/test_keras_mirrored.py
@@ -183,7 +183,10 @@ def train_model(
         elif step == "predict":
             model.predict(train_dataset, steps=4, callbacks=hooks, verbose=0)
 
-    smd.get_hook()._cleanup()
+    if not zcc:
+        hook._cleanup()
+    if zcc:
+        smd.get_hook()._cleanup()
     return strategy
 
 


### PR DESCRIPTION
...by fixing broken tests in test_keras_mirrored.py

Motive: Tensorflow 2.7.0 release

`smdebug.tensorflow.get_hook()` was returning `None`, which made many
tests fail, but this was actually a false alarm.
We just have to mark the version of tensorflow we are trying to release (`2.7.0`)
as a supported framework version, so `get_hook()` doesn't return
`None'...

I know what you think. It's not pythonic to silently fail and we should
instead throw an exception, but this code preceded me and I don't want
to introduce a breaking change (an exception being raised) and I don't
want to introduce warnings either in case `get_hook()' gets called
in unexpected ways multiple times during the lifecycle of a training job.

Instead, I just created a tests that alarms us of the situation
when `get_hook()` might return `None` when it's actually just because we forgot to update a constant.


### Description of changes:


#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
