### PR TITLE
add more descriptive message when json reading error happens

### DIFF
--- a/smdebug/profiler/system_profiler_file_parser.py
+++ b/smdebug/profiler/system_profiler_file_parser.py
@@ -1,6 +1,7 @@
 # First Party
 # Standard Library
 import json
+import os
 
 from smdebug.core.logger import get_logger
 from smdebug.profiler.utils import TimeUnits, convert_utc_timestamp_to_nanoseconds
@@ -51,16 +52,36 @@ class SystemProfilerEventParser:
         try:
             with open(eventfile) as json_data:
                 event_line = json_data.readline()
+                lineNum = 0
                 while event_line:
+                    lineNum += 1
                     json_event = json.loads(event_line)
                     event_line = json_data.readline()
                     self.read_event_from_dict(json_event)
         except Exception as e:
+            with open(eventfile) as j_data:
+                event_line = j_data.readline()
+                lineNumTotal = 0
+                while event_line:
+                    event_line = j_data.readline()
+                    lineNumTotal += 1
+            errStr = 'line No. ' + str(lineNum) + ' in line No.1 to No.' + str(lineNumTotal) + ' lines, has corrupted json format.  '
+            cur_dir = os.path.dirname(eventfile)
+            cur_dir_base = os.path.basename(cur_dir)
+            eventfile_base = os.path.basename(eventfile)
+            parent_dir = os.path.dirname(cur_dir)
+            time_stamp_files = [int(x.split('.')[0]) for x in os.listdir(cur_dir)]
+            time_stamp_dirs = [int(x) for x in os.listdir(parent_dir)]
+            file_pos = time_stamp_files.index(int(eventfile_base.split('.')[0]))
+            dir_pos = time_stamp_dirs.index(int(cur_dir_base))
+            errStr += 'output file '+eventfile_base + ' is file No.' + str(file_pos+1) + ' in file No.1 to No.' 
+            errStr += str(len(time_stamp_files)) +  ', the folder it locates is ' + cur_dir_base + ' which is folder No.' 
+            errStr += str(dir_pos+1) + " in folder No.1 to No." + str(len(time_stamp_dirs)) + "\n"
             self.logger.error(
-                f"Can't open profiler system metric file {eventfile}: Exception {str(e)}"
+                f"Can't open profiler system metric file {eventfile}: Exception {str(e)} \n {errStr}"
             )
             raise ValueError(
-                f"Can't open profiler system metric file {eventfile}: Exception {str(e)}"
+                f"Can't open profiler system metric file {eventfile}: Exception {str(e)} \n {errStr}"
             )
 
     def read_events_from_json_data(self, system_profiler_json_data):


### PR DESCRIPTION
### Description of changes:
 Print more informative message when json reading error occurs. Right now, errors like https://t.corp.amazon.com/V556254533 is reoccurring. By adding these extra information, I could find out if these error happens (1) with the last json file (2) the first json file (3) any json file. I hope it turns out to be case (1).  