### PR TITLE
fix: Remove Python 3.8 identity test warning

### DIFF
--- a/smdebug/profiler/system_metrics_reader.py
+++ b/smdebug/profiler/system_metrics_reader.py
@@ -60,7 +60,7 @@ class SystemMetricsReader(MetricsReaderBase):
         available timestamp
         """
 
-        if self._startAfter_prefix is not "":
+        if self._startAfter_prefix != "":
             if end_time_microseconds >= get_utctimestamp_us_since_epoch_from_system_profiler_file(
                 self._startAfter_prefix
             ):


### PR DESCRIPTION
### Description of changes:
Resolves `SyntaxWarning: "is not" with a literal. Did you mean "!="?` warning introduced in Python 3.8. Identity string comparison replaced with equality comparison. This warning appears in training and processing logs within SageMaker when running recent versions of Python (e.g. on recent DL AMIs/containers).

Before change:
```
> pytest tests/profiler/core/test_system_metric_reader.py::test_SystemLocalMetricsReader
================================================= test session starts ==================================================
platform linux -- Python 3.9.7, pytest-7.1.2, pluggy-1.0.0
rootdir: /<path>/sagemaker-debugger
collected 2 items

tests/profiler/core/test_system_metric_reader.py ..                                                              [100%]

=================================================== warnings summary ===================================================
smdebug/profiler/system_metrics_reader.py:63
  /<path>/sagemaker-debugger/smdebug/profiler/system_metrics_reader.py:63: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    if self._startAfter_prefix is not "":

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 2 passed, 1 warning in 0.21s =============================================
```

After change:
```
> pytest tests/profiler/core/test_system_metric_reader.py::test_SystemLocalMetricsReader
================================================= test session starts ==================================================
platform linux -- Python 3.9.7, pytest-7.1.2, pluggy-1.0.0
rootdir: /<path>/sagemaker-debugger
collected 2 items

tests/profiler/core/test_system_metric_reader.py ..                                                              [100%]

================================================== 2 passed in 0.29s ===================================================
```

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
