### PR TITLE
disabled zcc test for pt 1.12+

### DIFF
--- a/tests/zero_code_change/pt_utils.py
+++ b/tests/zero_code_change/pt_utils.py
@@ -95,3 +95,9 @@ def helper_torch_train(sim=None, script_mode=False, use_loss_module=False):
 
         if i == 499:
             break
+
+def is_pt_1_12_or_greater():
+    PT_VERSION = version.parse(torch.__version__)
+    if PT_VERSION >= version.parse("1.12.0"):
+        return True
+    return False

--- a/tests/zero_code_change/test_pytorch_integration.py
+++ b/tests/zero_code_change/test_pytorch_integration.py
@@ -13,7 +13,7 @@ import argparse
 # Third Party
 import pytest
 import torch
-from tests.zero_code_change.pt_utils import helper_torch_train
+from tests.zero_code_change.pt_utils import helper_torch_train, is_pt_1_12_or_greater
 
 # First Party
 import smdebug.pytorch as smd
@@ -21,8 +21,8 @@ from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 
 
 @pytest.mark.skipif(
-    torch.__version__ == "1.7.0",
-    reason="Disabling the test temporarily until we root cause the version incompatibility",
+    is_pt_1_12_or_greater(),
+    reason="ZCC integration deprecated in PT 1.12.0 and above",
 )
 @pytest.mark.parametrize("script_mode", [False])
 @pytest.mark.parametrize("use_loss_module", [True, False])


### PR DESCRIPTION
### Description of changes:

Disables ZCC tests for PyTorch 1.12 and above, due to ZCC removal.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
