### PR TITLE
fix horovod.torch import error

### DIFF
--- a/smdebug/core/utils.py
+++ b/smdebug/core/utils.py
@@ -67,6 +67,8 @@ except (ImportError, ModuleNotFoundError):
 
 try:
     import horovod.torch as hvd
+    if not hvd._MPI_LIB_AVAILABLE:
+        raise ImportError("MPI lib is missing. Reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.")
 
     # This redundant import is necessary because horovod does not raise an ImportError if the library is not present
     import torch  # noqa


### PR DESCRIPTION
### Description of changes:
I reproduce the error by running 
```
nvidia-docker run -it http://763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-training:0.4.2-gpu-py38-cu112-ubuntu20.04
python3
import horovod.torch
```
It gives me the following warning.
```
Extension horovod.torch has not been built: /usr/local/lib/python3.8/dist-packages/horovod/torch/mpi_lib/_mpi_lib.cpython-38-x86_64-linux-gnu.so not found
If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
Warning! MPI libs are missing, but python applications are still available.
```

Adding the MPI check during import should fix this.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
