### PR TITLE
Refactored MXNet/PyTorch/TF Exceptions, and End-of-training log directory check

### DIFF
--- a/smdebug/core/access_layer/utils.py
+++ b/smdebug/core/access_layer/utils.py
@@ -34,12 +34,9 @@ def training_has_ended(trial_prefix):
             f"The end of training job file will not be written for jobs running under SageMaker."
         )
         return
-    try:
-        check_dir_exists(trial_prefix)
-        # if path does not exist, then we don't need to write a file
-    except RuntimeError:
-        # dir exists
-        pass
+
+    check_dir_exists(trial_prefix)
+
     file_path = os.path.join(trial_prefix, END_OF_JOB_FILENAME)
     s3, bucket_name, key_name = is_s3(file_path)
     if s3:
@@ -124,11 +121,7 @@ def check_dir_exists(path):
             request = ListRequest(bucket_name, key_name)
             folder = S3Handler.list_prefixes([request])[0]
             if len(folder) > 0 and has_training_ended(folder[-1]):
-                raise RuntimeError(
-                    "The path:{} already exists on s3. "
-                    "Please provide a directory path that does "
-                    "not already exist.".format(path)
-                )
+                return True
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "NoSuchBucket":
                 # then we do not need to raise any error
@@ -137,8 +130,6 @@ def check_dir_exists(path):
                 # do not know the error
                 raise ex
     elif os.path.exists(path) and has_training_ended(path):
-        raise RuntimeError(
-            "The path:{} already exists on local disk. "
-            "Please provide a directory path that does "
-            "not already exist".format(path)
-        )
+        # Not changed to SMDebugError because it's interally caught
+        return True
+    return False

--- a/smdebug/core/access_layer/utils.py
+++ b/smdebug/core/access_layer/utils.py
@@ -35,6 +35,7 @@ def training_has_ended(trial_prefix):
         )
         return
 
+    # Calling to check other S3 configs aren't broken, since it'll raise an exception
     check_dir_exists(trial_prefix)
 
     file_path = os.path.join(trial_prefix, END_OF_JOB_FILENAME)

--- a/smdebug/core/hook_utils.py
+++ b/smdebug/core/hook_utils.py
@@ -1,6 +1,9 @@
 # Standard Library
 import os
 
+# First Party
+from smdebug.exceptions import SMDebugError
+
 # Local
 from .access_layer.utils import check_dir_exists
 from .logger import get_logger
@@ -18,7 +21,13 @@ def verify_and_get_out_dir(out_dir):
     # we check and raise error if directory already exists because
     # we don't want to merge tensors from current job with
     # tensors from previous job
-    check_dir_exists(out_dir)
+    # TODO: ljihyeon@ unit test
+    if check_dir_exists(out_dir):
+        raise SMDebugError(
+            "The path:{} already exists on s3. "
+            "Please provide a directory path that does "
+            "not already exist.".format(path)
+        )
     return out_dir
 
 

--- a/smdebug/core/hook_utils.py
+++ b/smdebug/core/hook_utils.py
@@ -2,7 +2,7 @@
 import os
 
 # First Party
-from smdebug.exceptions import SMDebugError
+from smdebug.exceptions import SMDebugRuntimeError
 
 # Local
 from .access_layer.utils import check_dir_exists
@@ -21,12 +21,11 @@ def verify_and_get_out_dir(out_dir):
     # we check and raise error if directory already exists because
     # we don't want to merge tensors from current job with
     # tensors from previous job
-    # TODO: ljihyeon@ unit test
     if check_dir_exists(out_dir):
-        raise SMDebugError(
+        raise SMDebugRuntimeError(
             "The path:{} already exists on s3. "
             "Please provide a directory path that does "
-            "not already exist.".format(path)
+            "not already exist.".format(out_dir)
         )
     return out_dir
 

--- a/smdebug/exceptions.py
+++ b/smdebug/exceptions.py
@@ -10,6 +10,14 @@ class SMDebugCustomerError(SMDebugError):
     pass
 
 
+class SMDebugTypeError(SMDebugError):
+    pass
+
+
+class SMDebugRuntimeError(SMDebugError):
+    pass
+
+
 class InvalidCollectionConfiguration(Exception):
     def __init__(self, c_name):
         self.c_name = c_name

--- a/smdebug/mxnet/graph.py
+++ b/smdebug/mxnet/graph.py
@@ -10,6 +10,7 @@ from smdebug.core.tfevent.proto.attr_value_pb2 import AttrValue
 from smdebug.core.tfevent.proto.graph_pb2 import GraphDef
 from smdebug.core.tfevent.proto.node_def_pb2 import NodeDef
 from smdebug.core.tfevent.proto.versions_pb2 import VersionDef
+from smdebug.exceptions import SMDebugError
 
 
 def _scoped_name(scope_name, node_name):
@@ -20,7 +21,7 @@ def _get_nodes_from_symbol(sym):
     """Given a symbol and shapes, return a list of `NodeDef`s for visualizing the
     the graph in TensorBoard."""
     if not isinstance(sym, Symbol):
-        raise TypeError(
+        raise SMDebugError(
             "sym must be an `mxnet.symbol.Symbol`," " received type {}".format(str(type(sym)))
         )
     conf = json.loads(sym.tojson())
@@ -90,13 +91,13 @@ def _net2pb(net):
     if isinstance(net, HybridBlock):
         # TODO(junwu): may need a more approprite way to get symbol from a HybridBlock
         if not net._cached_graph:
-            raise RuntimeError(
+            raise SMDebugError(
                 "Please first call net.hybridize() and then run forward with "
                 "this net at least once before calling add_graph()."
             )
         net = net._cached_graph[1]
     elif not isinstance(net, Symbol):
-        raise TypeError(
+        raise SMDebugError(
             "only accepts mxnet.gluon.HybridBlock and mxnet.symbol.Symbol "
             "as input network, received type {}".format(str(type(net)))
         )

--- a/smdebug/mxnet/graph.py
+++ b/smdebug/mxnet/graph.py
@@ -10,7 +10,7 @@ from smdebug.core.tfevent.proto.attr_value_pb2 import AttrValue
 from smdebug.core.tfevent.proto.graph_pb2 import GraphDef
 from smdebug.core.tfevent.proto.node_def_pb2 import NodeDef
 from smdebug.core.tfevent.proto.versions_pb2 import VersionDef
-from smdebug.exceptions import SMDebugError
+from smdebug.exceptions import SMDebugError, SMDebugRuntimeError, SMDebugTypeError
 
 
 def _scoped_name(scope_name, node_name):
@@ -91,13 +91,13 @@ def _net2pb(net):
     if isinstance(net, HybridBlock):
         # TODO(junwu): may need a more approprite way to get symbol from a HybridBlock
         if not net._cached_graph:
-            raise SMDebugError(
+            raise SMDebugRuntimeError(
                 "Please first call net.hybridize() and then run forward with "
                 "this net at least once before calling add_graph()."
             )
         net = net._cached_graph[1]
     elif not isinstance(net, Symbol):
-        raise SMDebugError(
+        raise SMDebugTypeError(
             "only accepts mxnet.gluon.HybridBlock and mxnet.symbol.Symbol "
             "as input network, received type {}".format(str(type(net)))
         )

--- a/smdebug/mxnet/hook.py
+++ b/smdebug/mxnet/hook.py
@@ -7,6 +7,7 @@ from smdebug.core.collection import DEFAULT_MXNET_COLLECTIONS, CollectionKeys
 from smdebug.core.hook import CallbackHook
 from smdebug.core.json_config import DEFAULT_WORKER_NAME
 from smdebug.core.utils import FRAMEWORK, error_handling_agent
+from smdebug.exceptions import SMDebugRuntimeError, SMDebugTypeError
 from smdebug.mxnet.collection import CollectionManager
 from smdebug.mxnet.graph import _net2pb
 from smdebug.mxnet.singleton_utils import set_hook
@@ -122,7 +123,7 @@ class Hook(CallbackHook):
                 tb_writer = self._maybe_get_tb_writer()
                 if tb_writer:
                     tb_writer.write_graph(_net2pb(self.model))
-            except (RuntimeError, TypeError) as e:
+            except (SMDebugRuntimeError, SMDebugTypeError) as e:
                 self.logger.warning(
                     f"Could not export model graph for tensorboard "
                     f"due to the mxnet exception: {e}"

--- a/smdebug/mxnet/utils.py
+++ b/smdebug/mxnet/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.core.reductions import get_numpy_reduction
 from smdebug.core.utils import make_numpy_array
+from smdebug.exceptions import SMDebugError
 
 
 def get_reduction_of_data(aggregation_name, tensor_data, tensor_name, abs=False):
@@ -30,7 +31,7 @@ def get_reduction_of_data(aggregation_name, tensor_data, tensor_name, abs=False)
             op = mx.ndarray.norm(data=tensor_data, ord=int(reduction_name[1]))
             return op
         else:
-            raise RuntimeError(
+            raise SMDebugError(
                 "Invalid normalization operation {0} for mx.NDArray".format(reduction_name)
             )
     elif hasattr(mx, reduction_name):
@@ -41,4 +42,4 @@ def get_reduction_of_data(aggregation_name, tensor_data, tensor_name, abs=False)
         f = getattr(np, aggregation_name)
         op = f(tensor_data)
         return op
-    raise RuntimeError("Invalid aggregation_name {0} for mx.NDArray".format(aggregation_name))
+    raise SMDebugError("Invalid aggregation_name {0} for mx.NDArray".format(aggregation_name))

--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -17,6 +17,7 @@ from smdebug.core.utils import (
     error_handling_agent,
     make_numpy_array,
 )
+from smdebug.exceptions import SMDebugError
 from smdebug.profiler.hvd_trace_file_rotation import HvdTraceFileRotation
 from smdebug.profiler.profiler_config_parser import MetricsCategory, get_profiler_config_parser
 from smdebug.profiler.profiler_constants import CONVERT_TO_MICROSECS
@@ -572,7 +573,7 @@ class Hook(CallbackHook):
         """
         # Typechecking
         if not isinstance(module, torch.nn.Module):
-            raise ValueError(
+            raise SMDebugError(
                 f"Module type {module.__class__.__name__} must be type torch.nn.Module"
             )
         # in case GPU is available but model has been loaded on CPU

--- a/smdebug/pytorch/utils.py
+++ b/smdebug/pytorch/utils.py
@@ -9,6 +9,7 @@ from packaging import version
 # First Party
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
 from smdebug.core.reductions import get_numpy_reduction
+from smdebug.exceptions import SMDebugError
 
 # Cached Pytorch Version
 PT_VERSION = version.parse(torch.__version__)
@@ -33,7 +34,7 @@ def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
         if reduction_name in ["l1", "l2"]:
             ord = int(reduction_name[1])
         else:
-            raise RuntimeError(
+            raise SMDebugError(
                 "Invalid normalization operation {0} for torch.Tensor".format(reduction_name)
             )
         op = torch.norm(tensor_data, p=ord)
@@ -42,7 +43,7 @@ def get_reduction_of_data(reduction_name, tensor_data, tensor_name, abs=False):
         f = getattr(torch, reduction_name)
         op = f(tensor_data)
         return op
-    raise RuntimeError("Invalid reduction_name {0}".format(reduction_name))
+    raise SMDebugError("Invalid reduction_name {0}".format(reduction_name))
 
 
 @lru_cache(maxsize=1)

--- a/smdebug/tensorflow/base_hook.py
+++ b/smdebug/tensorflow/base_hook.py
@@ -22,6 +22,7 @@ from smdebug.core.utils import (
     serialize_tf_device,
 )
 from smdebug.core.writer import FileWriter
+from smdebug.exceptions import SMDebugError
 from smdebug.profiler.profiler_config_parser import get_profiler_config_parser
 
 # Local
@@ -214,7 +215,7 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.NONE:
             return DEFAULT_WORKER_NAME
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
-            raise NotImplementedError
+            raise SMDebugError("TFDistrubutionStrategy is unsupported")
 
     def _get_default_collections(self):
         return DEFAULT_TF_COLLECTIONS
@@ -314,7 +315,7 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.PARAMETER_SERVER:
             self.chief_worker = get_chief_worker_from_tf_config(self.tf_config_json)
         elif self.distribution_strategy == TFDistributionStrategy.UNSUPPORTED:
-            raise NotImplementedError
+            raise SMDebugError("TFDistrubutionStrategy is unsupported")
 
     def _get_writers(self, tensor_name, tensor_ref) -> List[FileWriter]:
         """
@@ -356,7 +357,7 @@ class TensorflowBaseHook(BaseHook):
         elif self.distribution_strategy == TFDistributionStrategy.NONE:
             return self._get_main_writer()
         else:
-            raise NotImplementedError
+            raise SMDebugError("TFDistrubutionStrategy is unsupported")
         # when self.writer is None, returns empty list
         return []
 
@@ -396,7 +397,7 @@ class TensorflowBaseHook(BaseHook):
             if self.writer is None or only_initialize_if_missing is False:
                 self.writer = FileWriter(trial_dir=self.out_dir, step=self.step, worker=self.worker)
         else:
-            raise NotImplementedError
+            raise SMDebugError("TFDistrubutionStrategy is unsupported")
 
     def _close_writers(self) -> None:
         if self.dry_run:

--- a/smdebug/tensorflow/keras.py
+++ b/smdebug/tensorflow/keras.py
@@ -15,6 +15,7 @@ from tensorflow.python.util import nest
 from smdebug.core.locations import TraceFileLocation
 from smdebug.core.modes import ModeKeys
 from smdebug.core.utils import FRAMEWORK, error_handling_agent, match_inc
+from smdebug.exceptions import SMDebugError
 from smdebug.profiler.hvd_trace_file_rotation import HvdTraceFileRotation
 from smdebug.profiler.profiler_config_parser import MetricsCategory
 from smdebug.profiler.profiler_constants import (
@@ -210,7 +211,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                         # Ref: https://www.tensorflow.org/api_docs/python/tf/Tensor#experimental_ref
                         tensor = tensor.experimental_ref()
                     else:
-                        raise Exception(
+                        raise SMDebugError(
                             "Neither ref nor experimental_ref API present. Check TF version"
                         )
                 if not current_coll.has_tensor(tensor):
@@ -305,7 +306,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
                             )
                         )
                     else:
-                        raise NotImplementedError
+                        raise SMDebugError("Collection for this tensor type not implemented")
                 else:
                     # for second collection onwards
                     for t in tensor_refs:
@@ -667,7 +668,7 @@ class KerasHook(TensorflowBaseHook, tf.keras.callbacks.Callback):
             elif mode == ModeKeys.PREDICT:
                 x = self.model.predict_function
             else:
-                raise NotImplementedError
+                raise SMDebugError(f"SMDebug not supported for {mode}")
         else:
             x = self._get_distributed_model(mode)._distributed_function
         return x

--- a/smdebug/tensorflow/reductions.py
+++ b/smdebug/tensorflow/reductions.py
@@ -3,6 +3,7 @@ import tensorflow as tf
 
 # First Party
 from smdebug.core.reduction_config import ALLOWED_NORMS, ALLOWED_REDUCTIONS
+from smdebug.exceptions import SMDebugError
 
 
 def get_tensorflow_reduction(reduction_name, tensor, on_absolute_values=False):
@@ -22,6 +23,6 @@ def get_tensorflow_reduction(reduction_name, tensor, on_absolute_values=False):
         else:
             op = tf.norm(tensor, ord=ord)
     else:
-        raise RuntimeError(f"Invalid reduction name {reduction_name}")
+        raise SMDebugError(f"Invalid reduction name {reduction_name}")
 
     return op

--- a/smdebug/tensorflow/tensor_ref.py
+++ b/smdebug/tensorflow/tensor_ref.py
@@ -7,6 +7,7 @@ from tensorflow.python.distribute import values
 
 # First Party
 from smdebug.core.logger import get_logger
+from smdebug.exceptions import SMDebugError
 
 # Local
 from .utils import is_tf_version_2x, supported_tf_variables
@@ -22,9 +23,7 @@ def get_tf_names(arg):
     elif isinstance(arg, values.DistributedValues):
         tf_names = [v.name for v in arg._values]
     else:
-        raise NotImplementedError(
-            f"Smdebug currenty does not support:{arg} which of type:{type(arg)}"
-        )
+        raise SMDebugError(f"Smdebug currenty does not support:{arg} which of type:{type(arg)}")
     return tf_names
 
 

--- a/smdebug/tensorflow/utils.py
+++ b/smdebug/tensorflow/utils.py
@@ -13,6 +13,7 @@ from tensorflow.python.distribute import values
 # First Party
 from smdebug.core.modes import ModeKeys
 from smdebug.core.utils import error_handling_agent
+from smdebug.exceptions import SMDebugError
 
 # Cached TF Version
 TF_VERSION = version.parse(tf.__version__)
@@ -175,7 +176,7 @@ def get_original_fetch_ops(fetches):
     elif fetches is None:
         return []
     else:
-        raise RuntimeError("Invalid fetches")
+        raise SMDebugError("Invalid fetches")
 
 
 """"
@@ -288,7 +289,7 @@ def get_chief_worker_from_tf_config(tf_config_json: dict):
     if "chief" in tf_config_json["cluster"]:
         return "chief_0"
     else:
-        raise NotImplementedError
+        raise SMDebugError("Not implemented")
         # todo
 
 

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -8,6 +8,7 @@ from smdebug.core.access_layer.file import SMDEBUG_TEMP_PATH_SUFFIX, get_temp_pa
 from smdebug.core.access_layer.utils import training_has_ended
 from smdebug.core.hook_utils import verify_and_get_out_dir
 from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
+from smdebug.exceptions import SMDebugRuntimeError
 from smdebug.trials import create_trial
 
 # Local
@@ -37,7 +38,7 @@ def test_outdir_non_sagemaker():
         verify_and_get_out_dir(path)
         # should raise exception as dir present
         assert False
-    except RuntimeError as e:
+    except SMDebugRuntimeError as e:
         pass
 
 


### PR DESCRIPTION
### Description of changes:
Refactored all exception types under the `smdebug/mxnet`, `smdebug/pytorch`, and `smdebug/tensorflow` directories to return the `SMDebugError` exception type. Also changed the logic of the end of training log directory existence check in `smdebug/core/hook_utils.py` for the writer to return a boolean instead of raising an exception that gets caught later on, to make it clear that exceptions are generally meant to flow up to the customer, not to be used as a check.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
