### PR TITLE
disabled zcc tests for pt 1.10 and up

### DIFF
--- a/tests/zero_code_change/pt_utils.py
+++ b/tests/zero_code_change/pt_utils.py
@@ -96,8 +96,8 @@ def helper_torch_train(sim=None, script_mode=False, use_loss_module=False):
         if i == 499:
             break
 
-def is_pt_1_12_or_greater():
+def is_pt_1_10_or_greater():
     PT_VERSION = version.parse(torch.__version__)
-    if PT_VERSION >= version.parse("1.12.0"):
+    if PT_VERSION >= version.parse("1.10.0"):
         return True
     return False

--- a/tests/zero_code_change/test_pytorch_integration.py
+++ b/tests/zero_code_change/test_pytorch_integration.py
@@ -13,7 +13,7 @@ import argparse
 # Third Party
 import pytest
 import torch
-from tests.zero_code_change.pt_utils import helper_torch_train, is_pt_1_12_or_greater
+from tests.zero_code_change.pt_utils import helper_torch_train, is_pt_1_10_or_greater
 
 # First Party
 import smdebug.pytorch as smd
@@ -21,8 +21,8 @@ from smdebug.core.utils import SagemakerSimulator, ScriptSimulator
 
 
 @pytest.mark.skipif(
-    is_pt_1_12_or_greater(),
-    reason="ZCC integration deprecated in PT 1.12.0 and above",
+    is_pt_1_10_or_greater(),
+    reason="ZCC integration deprecated in PT 1.10.0 and above",
 )
 @pytest.mark.parametrize("script_mode", [False])
 @pytest.mark.parametrize("use_loss_module", [True, False])


### PR DESCRIPTION
### Description of changes:

Changed PyTorch ZCC test to disable at 1.10 instead of 1.12, in order to address performance regression.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
