### PR TITLE
skip trace.json file reader for tf 2.11 and above since it's no longe…

### DIFF
--- a/tests/profiler/tensorflow2/test_tf2_profiler.py
+++ b/tests/profiler/tensorflow2/test_tf2_profiler.py
@@ -5,6 +5,9 @@ import os
 import pytest
 from tests.profiler.tensorflow2.utils import verify_detailed_profiling
 from tests.tensorflow2.test_keras import helper_keras_fit
+import tensorflow as tf
+from packaging import version
+
 
 # First Party
 from smdebug.profiler.profiler_config_parser import ProfilerConfigParser
@@ -24,7 +27,8 @@ def tf2_profiler_config_parser_by_time(config_folder, monkeypatch):
     monkeypatch.setenv("SMPROFILER_CONFIG_PATH", config_path)
     return ProfilerConfigParser()
 
-
+@pytest.mark.skipif(version.parse(tf.__version__) > version.parse("2.10"),
+                    reason="tf 2.11 merged trace.json file to xplane.pb file.")
 def test_tf2_profiler_by_step(set_up_resource_config, tf2_profiler_config_parser_by_step, out_dir):
     """
     This test executes a TF2 training script, enables detailed TF profiling by step, and
@@ -38,7 +42,8 @@ def test_tf2_profiler_by_step(set_up_resource_config, tf2_profiler_config_parser
 
     verify_detailed_profiling(out_dir, 180)
 
-
+@pytest.mark.skipif(version.parse(tf.__version__) > version.parse("2.10"),
+                    reason="tf 2.11 merged trace.json file to xplane.pb file.")
 def test_tf2_profiler_by_time(tf2_profiler_config_parser_by_time, out_dir):
     """
     This test executes a TF2 training script, enables detailed TF profiling by time, and

--- a/tests/profiler/tensorflow2/utils.py
+++ b/tests/profiler/tensorflow2/utils.py
@@ -2,10 +2,6 @@
 import os
 from pathlib import Path
 
-# Third Party
-import tensorflow as tf
-from packaging import version
-
 # First Party
 from smdebug.profiler.profiler_constants import TENSORBOARDTIMELINE_SUFFIX
 from smdebug.profiler.tf_profiler_parser import TensorboardProfilerEvents
@@ -17,20 +13,19 @@ def verify_detailed_profiling(out_dir, expected_event_count):
     """
     t_events = TensorboardProfilerEvents()
 
-    if version.parse(tf.__version__) <= version.parse("2.10"):
-        # get tensorboard timeline files
-        files = list(Path(os.path.join(out_dir, "framework")).rglob(f"*{TENSORBOARDTIMELINE_SUFFIX}"))
+    # get tensorboard timeline files
+    files = list(Path(os.path.join(out_dir, "framework")).rglob(f"*{TENSORBOARDTIMELINE_SUFFIX}"))
 
-        assert len(files) == 1
+    assert len(files) == 1
 
-        trace_file = str(files[0])
-        t_events.read_events_from_file(trace_file)
+    trace_file = str(files[0])
+    t_events.read_events_from_file(trace_file)
 
-        all_trace_events = t_events.get_all_events()
-        num_trace_events = len(all_trace_events)
+    all_trace_events = t_events.get_all_events()
+    num_trace_events = len(all_trace_events)
 
-        print(f"Number of events read = {num_trace_events}")
+    print(f"Number of events read = {num_trace_events}")
 
-        # The number of events is varying by a small number on
-        # consecutive runs. Hence, the approximation in the below asserts.
-        assert num_trace_events >= expected_event_count, f"{num_trace_events}"
+    # The number of events is varying by a small number on
+    # consecutive runs. Hence, the approximation in the below asserts.
+    assert num_trace_events >= expected_event_count, f"{num_trace_events}"

--- a/tests/profiler/tensorflow2/utils.py
+++ b/tests/profiler/tensorflow2/utils.py
@@ -2,6 +2,10 @@
 import os
 from pathlib import Path
 
+# Third Party
+import tensorflow as tf
+from packaging import version
+
 # First Party
 from smdebug.profiler.profiler_constants import TENSORBOARDTIMELINE_SUFFIX
 from smdebug.profiler.tf_profiler_parser import TensorboardProfilerEvents
@@ -13,19 +17,20 @@ def verify_detailed_profiling(out_dir, expected_event_count):
     """
     t_events = TensorboardProfilerEvents()
 
-    # get tensorboard timeline files
-    files = list(Path(os.path.join(out_dir, "framework")).rglob(f"*{TENSORBOARDTIMELINE_SUFFIX}"))
+    if version.parse(tf.__version__) <= version.parse("2.10"):
+        # get tensorboard timeline files
+        files = list(Path(os.path.join(out_dir, "framework")).rglob(f"*{TENSORBOARDTIMELINE_SUFFIX}"))
 
-    assert len(files) == 1
+        assert len(files) == 1
 
-    trace_file = str(files[0])
-    t_events.read_events_from_file(trace_file)
+        trace_file = str(files[0])
+        t_events.read_events_from_file(trace_file)
 
-    all_trace_events = t_events.get_all_events()
-    num_trace_events = len(all_trace_events)
+        all_trace_events = t_events.get_all_events()
+        num_trace_events = len(all_trace_events)
 
-    print(f"Number of events read = {num_trace_events}")
+        print(f"Number of events read = {num_trace_events}")
 
-    # The number of events is varying by a small number on
-    # consecutive runs. Hence, the approximation in the below asserts.
-    assert num_trace_events >= expected_event_count, f"{num_trace_events}"
+        # The number of events is varying by a small number on
+        # consecutive runs. Hence, the approximation in the below asserts.
+        assert num_trace_events >= expected_event_count, f"{num_trace_events}"


### PR DESCRIPTION
### Description of changes:
TF 2.11 no longer have trace.json.gz file available. They merged all data to `xxx-.xplane.pb` file. This PR disables TF framework profiler support for TF 2.11 and above to unblock the AWS TF release.

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
