### PR TITLE
Changes to support tensorflow 2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ DOCLINES = (__doc__ or "").split("\n")
 FRAMEWORKS = ["tensorflow", "pytorch", "mxnet", "xgboost"]
 TESTS_PACKAGES = ["pytest", "torchvision", "pandas"]
 INSTALL_REQUIRES = [
-    "protobuf>=3.20.0,<=3.20.2",
+    "protobuf>=3.20.0,<=3.20.3",
     "numpy>=1.16.0",
     "packaging",
     "boto3>=1.10.32",

--- a/smdebug/core/tfevent/proto/types.proto
+++ b/smdebug/core/tfevent/proto/types.proto
@@ -38,6 +38,9 @@ enum DataType {
   DT_VARIANT = 21;  // Arbitrary C++ data types
   DT_UINT32 = 22;
   DT_UINT64 = 23;
+  DT_FLOAT8_E5M2 = 24;    // 5 exponent bits, 2 mantissa bits.
+  DT_FLOAT8_E4M3FN = 25;  // 4 exponent bits, 3 mantissa bits, finite-only, with
+                          // 2 NaNs (0bS1111111).
 
   // TODO(josh11b): DT_GENERIC_PROTO = ??;
   // TODO(jeff,josh11b): DT_UINT64?  DT_UINT32?
@@ -67,5 +70,7 @@ enum DataType {
   DT_VARIANT_REF = 121;
   DT_UINT32_REF = 122;
   DT_UINT64_REF = 123;
+  DT_FLOAT8_E5M2_REF = 124;
+  DT_FLOAT8_E4M3FN_REF = 125;
 }
 // LINT.ThenChange(https://www.tensorflow.org/code/tensorflow/c/c_api.h,https://www.tensorflow.org/code/tensorflow/go/tensor.go)

--- a/smdebug/core/tfevent/util.py
+++ b/smdebug/core/tfevent/util.py
@@ -1,5 +1,6 @@
 # Third Party
 import numpy as np
+from tensorflow.python.lib.core import _pywrap_float8
 
 # First Party
 from smdebug.core.logger import get_logger
@@ -8,6 +9,7 @@ from smdebug.exceptions import SMDebugTypeError
 # Local
 from .proto.tensor_pb2 import TensorProto
 from .proto.tensor_shape_pb2 import TensorShapeProto
+
 
 logger = get_logger()
 
@@ -33,6 +35,8 @@ _NP_DATATYPE_TO_PROTO_DATATYPE = {
     np.dtype([("qint16", "<i2")]): "DT_QINT16",
     np.dtype([("quint16", "<u2")]): "DT_UINT16",
     np.dtype([("qint32", "<i4")]): "DT_INT32",
+    np.dtype(_pywrap_float8.TF_float8_e5m2_type()): "DT_FLOAT8_E5M2",
+    np.dtype(_pywrap_float8.TF_float8_e4m3fn_type()): "DT_FLOAT8_E4M3FN",
 }
 
 
@@ -40,6 +44,7 @@ def _get_proto_dtype(npdtype):
     if hasattr(npdtype, "kind"):
         if npdtype.kind == "U" or npdtype.kind == "O" or npdtype.kind == "S":
             return False, "DT_STRING"
+
     try:
         return True, _NP_DATATYPE_TO_PROTO_DATATYPE[npdtype]
     except KeyError:

--- a/tests/tensorflow2/test_embedding_grad.py
+++ b/tests/tensorflow2/test_embedding_grad.py
@@ -81,7 +81,6 @@ def train(out_dir):
                                run_eagerly=True)
 
     sub_classing_model.fit(x_train, encoded_Y, batch_size=128, epochs=1, callbacks=[hook])
-    print(sub_classing_model.summary())
 
 
 def test_embedding_grad(out_dir):

--- a/tests/tensorflow2/test_embedding_grad.py
+++ b/tests/tensorflow2/test_embedding_grad.py
@@ -71,6 +71,7 @@ def train(out_dir):
     encoder.fit(y_train)
     encoded_Y = encoder.transform(y_train)
     sub_classing_model = ModelSubClassing(hook)
+
     hook.register_model(sub_classing_model)
 
     optimizer = Adam()
@@ -78,15 +79,12 @@ def train(out_dir):
 
     sub_classing_model.compile(optimizer=optimizer, loss=tf.keras.losses.BinaryCrossentropy(),
                                run_eagerly=True)
+
     sub_classing_model.fit(x_train, encoded_Y, batch_size=128, epochs=1, callbacks=[hook])
+    print(sub_classing_model.summary())
 
 
 def test_embedding_grad(out_dir):
     train(out_dir)
     trial = smd.create_trial(path=out_dir)
-    output = ['gradients/model_sub_classing/dense/biasGrad',
-              'gradients/model_sub_classing/dense/kernelGrad',
-              'gradients/model_sub_classing/dense_1/biasGrad',
-              'gradients/model_sub_classing/dense_1/kernelGrad',
-              'gradients/model_sub_classing/embedding/embeddingsGrad']
-    assert trial.tensor_names(collection="gradients") == output
+    assert len(trial.tensor_names(collection="gradients")) == 5

--- a/tests/tensorflow2/test_estimator.py
+++ b/tests/tensorflow2/test_estimator.py
@@ -2,7 +2,7 @@
 # Third Party
 import pytest
 import tensorflow.compat.v2 as tf
-from tests.tensorflow2.utils import is_tf_version_greater_than_2_4_x
+from tests.tensorflow2.utils import is_tf_version_greater_than_2_4_x, is_greater_than_tf_2_11
 from tests.zero_code_change.tf_utils import get_estimator, get_input_fns
 
 # First Party
@@ -10,6 +10,9 @@ import smdebug.tensorflow as smd
 from smdebug.core.collection import CollectionKeys
 
 
+@pytest.mark.skipif(
+    is_greater_than_tf_2_11(), reason="Unsupported with TF 2.12 due to breaking changes"
+)
 @pytest.mark.parametrize("saveall", [True, False])
 def test_estimator(out_dir, tf_eager_mode, saveall):
     """ Works as intended. """
@@ -19,7 +22,6 @@ def test_estimator(out_dir, tf_eager_mode, saveall):
     tf.keras.backend.clear_session()
     mnist_classifier = get_estimator()
     train_input_fn, eval_input_fn = get_input_fns()
-
     # Train and evaluate
     train_steps, eval_steps = 8, 2
     hook = smd.EstimatorHook(out_dir=out_dir, save_all=saveall)
@@ -27,7 +29,6 @@ def test_estimator(out_dir, tf_eager_mode, saveall):
     mnist_classifier.train(input_fn=train_input_fn, steps=train_steps, hooks=[hook])
     hook.set_mode(mode=smd.modes.EVAL)
     mnist_classifier.evaluate(input_fn=eval_input_fn, steps=eval_steps, hooks=[hook])
-
     # Check that hook created and tensors saved
     trial = smd.create_trial(path=out_dir)
     tnames = trial.tensor_names()
@@ -48,6 +49,9 @@ def test_estimator(out_dir, tf_eager_mode, saveall):
         assert len(trial.tensor_names(collection=CollectionKeys.LOSSES)) == 1
 
 
+@pytest.mark.skipif(
+    is_greater_than_tf_2_11(), reason="Unsupported with TF 2.12 due to breaking changes"
+)
 @pytest.mark.parametrize("saveall", [True, False])
 def test_linear_classifier(out_dir, tf_eager_mode, saveall):
     """ Works as intended. """

--- a/tests/tensorflow2/test_grad_tape_tf_function.py
+++ b/tests/tensorflow2/test_grad_tape_tf_function.py
@@ -69,14 +69,8 @@ def test_gradtape_tf_function(out_dir):
 
     trial = smd.create_trial(out_dir)
     assert trial.tensor_names(collection=CollectionKeys.LOSSES) == ["loss"]
-    assert trial.tensor_names(collection=CollectionKeys.WEIGHTS) == [
-        "weights/dense/kernel:0",
-        "weights/dense_1/kernel:0",
-    ]
-    assert trial.tensor_names(collection=CollectionKeys.BIASES) == [
-        "weights/dense/bias:0",
-        "weights/dense_1/bias:0",
-    ]
+    assert len(trial.tensor_names(collection=CollectionKeys.WEIGHTS)) == 2
+    assert len(trial.tensor_names(collection=CollectionKeys.BIASES)) == 2
     assert trial.tensor_names(collection=CollectionKeys.OPTIMIZER_VARIABLES) == [
         "Adam/beta_1:0",
         "Adam/beta_2:0",

--- a/tests/tensorflow2/test_keras.py
+++ b/tests/tensorflow2/test_keras.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
-from tests.tensorflow2.utils import is_greater_than_tf_2_2, is_tf_2_3, is_tf_2_6
+from tests.tensorflow2.utils import is_greater_than_tf_2_2, is_tf_2_3, is_tf_2_6, is_greater_than_tf_2_11
 from tests.tensorflow.utils import create_trial_fast_refresh
 from tests.utils import verify_shapes
 from packaging import version
@@ -890,6 +890,9 @@ def test_save_tensors(out_dir, tf_eager_mode):
         assert trial.tensor(tname).value(0) is not None
 
 
+@pytest.mark.skipif(
+    is_greater_than_tf_2_11(), reason="Unsupported with TF 2.12 due to breaking changes"
+)
 def test_keras_to_estimator(out_dir, tf_eager_mode):
     if not tf_eager_mode:
         tf.compat.v1.disable_eager_execution()

--- a/tests/tensorflow2/test_tensorflow2_datatypes.py
+++ b/tests/tensorflow2/test_tensorflow2_datatypes.py
@@ -28,7 +28,6 @@ def test_tensorflow2_datatypes():
     for _type in _NP_TO_TF:
         try:
             _get_proto_dtype(np.dtype(_type))
-
         except Exception:
             if _NP_TO_TF[_type] != tf.bfloat16:
                 # bfloat16 is only supported on TPUs.

--- a/tests/tensorflow2/test_tensorflow2_datatypes.py
+++ b/tests/tensorflow2/test_tensorflow2_datatypes.py
@@ -16,7 +16,7 @@ def test_tensorflow2_datatypes():
     # _NP_TO_TF contains all the mappings
     # of numpy to tf types
     try:
-        from tensorflow.python import _pywrap_bfloat16
+        from tensorflow.python.lib.core import _pywrap_bfloat16
 
         # TF 2.x.x Implements a Custom Numpy Datatype for Brain Floating Type
         # Which is currently only supported on TPUs
@@ -28,6 +28,7 @@ def test_tensorflow2_datatypes():
     for _type in _NP_TO_TF:
         try:
             _get_proto_dtype(np.dtype(_type))
+
         except Exception:
             if _NP_TO_TF[_type] != tf.bfloat16:
                 # bfloat16 is only supported on TPUs.

--- a/tests/tensorflow2/utils.py
+++ b/tests/tensorflow2/utils.py
@@ -21,6 +21,13 @@ def is_greater_than_tf_2_2():
         return True
     return False
 
+def is_greater_than_tf_2_11():
+    """
+    Session hook is deprecated since 2.12, so we do skipping all session hook related tests
+    """
+    if TF_VERSION >= version.parse("2.12.0") or 'rc' in tf.__version__:
+        return True
+    return False
 
 def is_tf_2_6():
     if TF_VERSION >= version.parse("2.6.0"):


### PR DESCRIPTION
### Description of changes:
- Upgrade protobuf version to 3.20.3
- Add new tensorflow experimental data type float8
- Skip estimatorhook(sessionhook) tests due to deprecation of SessionRunHook class in tensorflow 2.12: https://www.tensorflow.org/guide/migrate/sessionrunhook_callback
- Changed gradients tests output validation because of keras layer naming instability

#### Style and formatting:

I have run `pre-commit install && pre-commit run --all-files` to ensure that auto-formatting happens with every commit.

#### Issue number, if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
