### PR TITLE
Fix default value of end_time in update_end_time

### DIFF
--- a/smdebug/pytorch/hook.py
+++ b/smdebug/pytorch/hook.py
@@ -61,7 +61,9 @@ class Hook(CallbackHook):
             self.op_name = op_name
             self.kwargs = kwargs
 
-        def update_end_time(self, end_time=time.time()):
+        def update_end_time(self, end_time=None):
+            if end_time is None:
+                end_time = time.time()
             self.end_time = end_time
 
     @error_handling_agent.catch_smdebug_errors()


### PR DESCRIPTION
### Description of changes:
Using `time.time()` in the definition of the method would freeze the default to the time at the definition. Defining it in the body allows to query the current time when the method is called.

#### Style and formatting:
I have *not* run `pre-commit install && pre-commit run --all-files`, as it seems to be broken (see issue #664).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
